### PR TITLE
add continuous switch according to official app only available when manual mode is on. Fix #48. 

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -147,7 +147,7 @@ class DeyeEntity(CoordinatorEntity, Entity):
         """Push command to a queue and deal with them together."""
         self.async_write_ha_state()
         self.hass.bus.fire(
-            "call_humidifier_method", {"prop": attribute, "value": value}
+            "call_humidifier_method", {"device_id": self._device["device_id"], "prop": attribute, "value": value}
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -147,7 +147,8 @@ class DeyeEntity(CoordinatorEntity, Entity):
         """Push command to a queue and deal with them together."""
         self.async_write_ha_state()
         self.hass.bus.fire(
-            "call_humidifier_method", {"device_id": self._device["device_id"], "prop": attribute, "value": value}
+            "call_humidifier_method",
+            {"device_id": self._device["device_id"], "prop": attribute, "value": value},
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -91,9 +91,7 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator):
                 self._device["device_id"],
                 QUERY_DEVICE_STATE_COMMAND,
             )
-            response = await asyncio.wait_for(
-                self.receive_queue.get(), timeout=10
-            )
+            response = await asyncio.wait_for(self.receive_queue.get(), timeout=10)
             return response
         elif self._device["platform"] == 2:
             response = DeyeDeviceState(

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -93,8 +93,7 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator):
             )
             response = await asyncio.wait_for(
                 self.receive_queue.get(), timeout=10
-            )  # 设置超时时间
-            # _LOGGER.error(response.to_command().json())
+            )
             return response
         elif self._device["platform"] == 2:
             response = DeyeDeviceState(

--- a/custom_components/deye_dehumidifier/icons.json
+++ b/custom_components/deye_dehumidifier/icons.json
@@ -14,6 +14,12 @@
       }
     },
     "switch": {
+      "continuous": {
+        "default": "mdi:autorenew",
+        "state": {
+          "off": "mdi:autorenew-off"
+        }
+      },
       "child_lock": {
         "default": "mdi:baby-carriage",
         "state": {

--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
   "requirements": ["libdeye==1.3.0"],
-  "version": "1.6.0"
+  "version": "1.6.2"
 }

--- a/custom_components/deye_dehumidifier/switch.py
+++ b/custom_components/deye_dehumidifier/switch.py
@@ -11,10 +11,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from libdeye.cloud_api import DeyeCloudApi
 from libdeye.mqtt_client import DeyeMqttClient
-from libdeye.types import DeyeApiResponseDeviceInfo
+from libdeye.types import DeyeApiResponseDeviceInfo, DeyeDeviceMode
 from libdeye.utils import get_product_feature_config
 
-from libdeye.types import DeyeDeviceMode
 from . import DeyeEntity
 from .const import DATA_CLOUD_API, DATA_DEVICE_LIST, DATA_MQTT_CLIENT, DOMAIN
 
@@ -175,7 +174,9 @@ class DeyeContinuousSwitch(DeyeEntity, SwitchEntity):
 
     @property
     def available(self):
-        return super().available and self.device_state.mode == DeyeDeviceMode.MANUAL_MODE
+        return (
+            super().available and self.device_state.mode == DeyeDeviceMode.MANUAL_MODE
+        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -50,6 +50,9 @@
       }
     },
     "switch": {
+      "continuous": {
+        "name": "Continuous Dehumidify"
+      },
       "child_lock": {
         "name": "Child Lock"
       },

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -50,6 +50,9 @@
       }
     },
     "switch": {
+      "continuous": {
+        "name": "Desumidificação contínua"
+      },
       "child_lock": {
         "name": "Bloqueio anti crianças"
       },

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -50,6 +50,9 @@
       }
     },
     "switch": {
+      "continuous": {
+        "name": "连续除湿"
+      },
       "child_lock": {
         "name": "童锁"
       },

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -34,7 +34,7 @@
           "mode": {
             "state": {
               "manual": "手动",
-              "air_purifier": "清新",
+              "air_purifier": "净化",
               "clothes_dryer": "干衣"
             }
           }

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -50,6 +50,9 @@
       }
     },
     "switch": {
+      "continuous": {
+        "name": "連續除濕"
+      },
       "child_lock": {
         "name": "童鎖"
       },

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -34,7 +34,7 @@
           "mode": {
             "state": {
               "manual": "手動",
-              "air_purifier": "清新",
+              "air_purifier": "淨化",
               "clothes_dryer": "乾衣"
             }
           }


### PR DESCRIPTION
- fix: Change the name of "Fresh" mode to "Purification" synchronized with the official app.
- fix: command sent to wrong device when multiple device available.
- feat: add continuous switch according to official app only available when manual mode is on. Fix #48. 