### PR TITLE
Send only changed Fog device properties via separated HA state. 

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -78,9 +78,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_list = list(
             filter(
                 # The product_type was initially set to "dehumidifier"
-                # but at some point (around 04/15/2025) it was changed to "除湿机"
+                # but at some point (around 04/15/2025) it was changed to "除湿机" or "更多"
                 lambda d: d["product_type"] == "dehumidifier"
-                or d["product_type"] == "除湿机",
+                or d["product_type"] == "除湿机" or d["product_type"] == "更多",
                 await cloud_api.get_device_list(),
             )
         )

--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -78,10 +78,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_list = list(
             filter(
                 # The product_type was initially set to "dehumidifier"
-                # but at some point (around 04/15/2025) it was changed to "除湿机" or "更多"
+                # but at some point (around 06/18/2025) it was changed to "除湿机" or "其他"
                 lambda d: d["product_type"] == "dehumidifier"
                 or d["product_type"] == "除湿机"
-                or d["product_type"] == "更多",
+                or d["product_type"] == "其他",
                 await cloud_api.get_device_list(),
             )
         )

--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -179,10 +179,24 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator], Entity):
 
     async def _publish_command(self) -> None:
         """Publish commands to the device."""
+        command = self.coordinator.data.state.to_command()
+        if isinstance(self.coordinator.mqtt_client, DeyeFogMqttClient):
+            properties = command.to_json_diff(self.coordinator.data.reported_state)
+            if not properties:
+                return
+            await self.coordinator.mqtt_client.publish_command(
+                self._device["product_id"],
+                self._device["device_id"],
+                command,
+                properties=properties,
+            )
+            self.coordinator.sync_reported_state_after_publish()
+            return
+
         await self.coordinator.mqtt_client.publish_command(
             self._device["product_id"],
             self._device["device_id"],
-            self.coordinator.data.state.to_command(),
+            command,
         )
 
     async def publish_command_from_current_state(self) -> None:

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class DeyeDeviceData(NamedTuple):
+    reported_state: DeyeDeviceState
     state: DeyeDeviceState
     available: bool
 
@@ -44,11 +45,13 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
 
     async def _async_setup(self) -> None:
         """Set up the coordinator"""
+        reported_state = DeyeDeviceState(
+            self._device["payload"]
+            or "1411000000370000000000000000003C3C0000000000"  # 20°C/60%RH as the default state
+        )
         self.data = DeyeDeviceData(
-            state=DeyeDeviceState(
-                self._device["payload"]
-                or "1411000000370000000000000000003C3C0000000000"  # 20°C/60%RH as the default state
-            ),
+            reported_state=reported_state,
+            state=reported_state.copy(),
             available=self._device["online"],
         )
         self.mqtt_client.subscribe_state_change(
@@ -78,13 +81,29 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
         if self.state_update_muted:
             return
         self.async_set_updated_data(
-            DeyeDeviceData(state=state, available=self.data.available)
+            DeyeDeviceData(
+                reported_state=state,
+                state=state.copy(),
+                available=self.data.available,
+            )
         )
 
     def update_device_availability(self, available: bool) -> None:
         """Will be called when received device availability change."""
         self.async_set_updated_data(
-            DeyeDeviceData(state=self.data.state, available=available)
+            DeyeDeviceData(
+                reported_state=self.data.reported_state,
+                state=self.data.state,
+                available=available,
+            )
+        )
+
+    def sync_reported_state_after_publish(self) -> None:
+        """Align reported state with the desired state after a successful publish."""
+        self.data = DeyeDeviceData(
+            reported_state=self.data.state.copy(),
+            state=self.data.state,
+            available=self.data.available,
         )
 
     async def poll_device_state(self) -> DeyeDeviceData:
@@ -101,10 +120,13 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
                 QUERY_DEVICE_STATE_COMMAND_CLASSIC,
             )
             return self.data
-        else:
-            return DeyeDeviceData(
-                state=await self.mqtt_client.query_device_state(
-                    self._device["product_id"], self._device["device_id"]
-                ),
-                available=self.data.available,
-            )
+
+        reported_state = await self.mqtt_client.query_device_state(
+            self._device["product_id"],
+            self._device["device_id"],
+        )
+        return DeyeDeviceData(
+            reported_state=reported_state,
+            state=reported_state.copy(),
+            available=self.data.available,
+        )


### PR DESCRIPTION
Fog platform property updates now diff desired state against reported device state instead of sending the full command payload. HA coordinator keeps reported_state (from MQTT/poll) and an independent mutable state copy for entity writes, so in-place UI updates no longer invalidate the diff baseline.

Add DeyeDeviceState.copy() and DeyeDeviceCommand.to_json_diff(). DeyeFogMqttClient.publish_command() accepts an optional properties dict; HA builds the diff and syncs reported_state after publish.