### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **Home Assistant custom integration** (`custom_components/deye_dehumidifier`) for Deye dehumidifiers. It is not a standalone app — the "application" is a Home Assistant instance with this integration loaded. Requires **Python 3.13**.
+
+### Environment / tooling
+- Dependencies live in a local venv at `.venv`, created with [`uv`](https://docs.astral.sh/uv/) (installed at `~/.local/bin`). The startup update script handles installing Python 3.13, creating `.venv`, and installing `.[dev]`.
+- Activate the venv with `source .venv/bin/activate` (or prefix commands with `.venv/bin/`). If `uv` is not on your PATH, use `~/.local/bin/uv`.
+
+### Lint / type / version checks (mirrors CI in `.github/workflows`)
+- Type check: `mypy .`
+- Version consistency: `python scripts/check_versions.py`
+- Full lint suite (isort, flake8, black, file hygiene): `pre-commit run --all-files`
+
+### Running the app (Home Assistant dev instance)
+- A HA config dir lives at `/home/ubuntu/ha-config`. It contains `configuration.yaml` and a symlink `custom_components/deye_dehumidifier -> /workspace/custom_components/deye_dehumidifier`. If that dir/symlink is missing (e.g. fresh VM), recreate it:
+  ```sh
+  mkdir -p /home/ubuntu/ha-config/custom_components
+  ln -sfn /workspace/custom_components/deye_dehumidifier /home/ubuntu/ha-config/custom_components/deye_dehumidifier
+  ```
+- Start HA: `source .venv/bin/activate && hass -c /home/ubuntu/ha-config`. UI is at `http://localhost:8123`.
+- An owner account is already onboarded: `testuser` / `testpassword123` (persists via snapshot).
+
+### Non-obvious caveats
+- **Dependency pins to run HA:** installing `.[dev]` resolves two transitive deps to versions that crash HA 2024.11 on startup. They must be pinned back: `josepy<2` (newer `josepy` removed `ComparableX509` needed by `acme`) and `pycares<5` (newer `pycares` changed `getaddrinfo` signature, breaking `aiodns`). The update script applies these pins after the main install.
+- **`default_config`** pulls optional components (camera/stream/voice) that compile native wheels (`PyTurboJPEG`, `pymicro-vad`, `pyspeex-noise`); these need system packages `build-essential` and `libturbojpeg0-dev` (already in the snapshot). These components are unrelated to this integration — if they fail to set up, it does not affect `deye_dehumidifier`.
+- **Completing the config flow** (adding a real device) requires real Deye Smart app credentials (phone number + password) and cloud/MQTT access. Without credentials you can only verify the integration loads and its config flow form opens — actual device data cannot be fetched.
+- There are no automated unit tests in this repo; correctness is enforced via `mypy` + `pre-commit` + `scripts/check_versions.py`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Home Assistant custom integration (Deye dehumidifiers) and documents durable run/test instructions for future Cloud Agents.

This is a Home Assistant custom integration — the "application" is a Home Assistant instance with `custom_components/deye_dehumidifier` loaded (Python 3.13).

### What was set up
- Installed `uv` + Python 3.13, created `.venv`, installed `.[dev]` (homeassistant 2024.11.0, libdeye 2.1.4, mypy, pre-commit).
- Pinned two transitive deps required to actually run Home Assistant: `josepy<2` and `pycares<5` (newer versions crash HA 2024.11 on startup).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering tooling, lint/type checks, how to run the HA dev instance, and non-obvious caveats.

### Verification
- `mypy .` → clean
- `python scripts/check_versions.py` → consistent
- `pre-commit run --all-files` → all hooks pass
- Ran Home Assistant (`hass -c /home/ubuntu/ha-config`), confirmed the `deye_dehumidifier` integration loads and its config flow opens in the UI.

### Hello world
Onboarded HA, navigated to Settings → Devices & Services → Add Integration, searched "Deye", and opened the **Deye Dehumidifier** config flow form (Phone Number + Password). Completing the flow requires real Deye Smart app credentials, which are not available in this environment.

[Deye Dehumidifier in integration search](https://cursor.com/agents/bc-61715937-7f88-4ec2-a278-2d0be99cfff9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeye_search.webp)
[Deye Dehumidifier config flow form](https://cursor.com/agents/bc-61715937-7f88-4ec2-a278-2d0be99cfff9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeye_config_flow.webp)

### Notes
- No source code changed; only `AGENTS.md` was added.
- The update script (uv venv + install + pins) is configured separately as the VM startup script.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61715937-7f88-4ec2-a278-2d0be99cfff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61715937-7f88-4ec2-a278-2d0be99cfff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

