### PR TITLE
fix(fog): re-assert power and mode on wake, avoid low humidity in auto

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -23,6 +23,7 @@ from libdeye.cloud_api import (
     DeyeCloudApiInvalidAuthError,
     DeyeIotPlatform,
 )
+from libdeye.const import DeyeDeviceMode
 from libdeye.mqtt_client import (
     BaseDeyeMqttClient,
     DeyeClassicMqttClient,
@@ -184,6 +185,23 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator], Entity):
         command = self.coordinator.data.state.to_command()
         if isinstance(self.coordinator.mqtt_client, DeyeFogMqttClient):
             properties = command.to_json_diff(self.coordinator.data.reported_state)
+            # When powered off, the device loses its mode and reverts to manual
+            # at the minimum humidity. Re-assert power + mode together on wake,
+            # and avoid sending a low SetHumidity in auto mode (which would
+            # otherwise force the device into continuous/manual operation).
+            powering_on = (
+                command.power_switch
+                and not self.coordinator.data.reported_state.power_switch
+            )
+            if powering_on:
+                properties["Power"] = 1
+                properties["Mode"] = int(command.mode)
+            elif properties and command.power_switch and "Power" not in properties:
+                # Some Deye models (e.g. U20A3, V58A3) turn the device off when
+                # a partial Fog update omits the Power property while on.
+                properties["Power"] = 1
+            if command.mode == DeyeDeviceMode.AUTO_MODE:
+                properties.pop("SetHumidity", None)
             if not properties:
                 return
             await self.coordinator.mqtt_client.publish_command(


### PR DESCRIPTION
## Problem

On a **DYD-V58A3** (Fog platform), powering the dehumidifier on while in **auto** mode lands it in **manual mode + continuous dehumidify** (target humidity snapped to the minimum 25%). Every power-off also reset the device to manual/25%.

Root cause, confirmed via logging: when the device is powered **off**, it reverts to manual at min humidity. The off→on wake-up command was built as a partial diff against the *reported* state, so `Mode` was often omitted (HA believed the device was already in auto from an earlier optimistic sync). The device then booted into its native manual/continuous state.

## Fix

In `_publish_command` (Fog path):

- **Re-assert `Power` and `Mode` together on an off→on transition**, so the device wakes into the requested mode instead of manual.
- **Skip `SetHumidity` on auto-mode publishes** — a leftover low target (25%, from the continuous switch) would otherwise force the device into continuous/manual.
- Keep injecting `Power=1` on partial updates while the device is on (some models, e.g. U20A3/V58A3, power off if it's omitted).

Verified live on the user's V58A3: power-on in auto now stays in auto, and repeated power cycles are consistent.

## Related

- libdeye marks the V58A3 as `requires_power_in_fog_partial_updates`: https://github.com/stackia/libdeye/pull/64