### PR TITLE
chore(release): prepare 2.1.8

### DIFF
--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
   "requirements": ["libdeye==2.1.6"],
-  "version": "2.1.7"
+  "version": "2.1.8"
 }

--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/stackia/ha-deye-dehumidifier",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
-  "requirements": ["libdeye==2.1.5"],
+  "requirements": ["libdeye==2.1.6"],
   "version": "2.1.7"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
     =custom_components
 python_requires = >=3.13
 install_requires =
-    libdeye==2.1.5
+    libdeye==2.1.6
 
 
 [options.packages.find]


### PR DESCRIPTION
## Summary

Prepare ha-deye-dehumidifier 2.1.8:

- upgrade the pinned libdeye dependency from 2.1.5 to 2.1.6 in the Home Assistant manifest and package metadata
- bump the integration version from 2.1.7 to 2.1.8

libdeye 2.1.6 includes stackia/libdeye#65, which moves the tested DYD-V58A3 Fog command behavior into the library. This keeps product-specific command handling out of the Home Assistant integration and replaces the integration-side approach proposed in #103.

## Validation

- `python3 scripts/check_versions.py`
- `uvx pre-commit run --files custom_components/deye_dehumidifier/manifest.json setup.cfg`
- `git diff --check`
- Existing PR checks passed before the version bump; the pushed commit triggers them again