### PR TITLE
fix: connect the Fog MQTT client for every device routed to it

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -98,7 +98,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         if any(device["platform"] == DeyeIotPlatform.Classic for device in device_list):
             await classic_mqtt_client.connect()
-        if any(device["platform"] == DeyeIotPlatform.Fog for device in device_list):
+        if any(device["platform"] != DeyeIotPlatform.Classic for device in device_list):
             await fog_mqtt_client.connect()
 
         coordinator_map: dict[str, DeyeDataUpdateCoordinator] = {}


### PR DESCRIPTION
### The bug

`async_setup_entry` routes devices to a client with

```python
classic_mqtt_client if device["platform"] == DeyeIotPlatform.Classic else fog_mqtt_client
```

but only connects the Fog client when the platform is *exactly* `Fog`:

```python
if any(device["platform"] == DeyeIotPlatform.Fog for device in device_list):
    await fog_mqtt_client.connect()
```

A device whose platform is neither value therefore gets a Fog client that was **never connected**. Since `_topic` is assigned only in `DeyeFogMqttClient._set_mqtt_info()` — which `connect()` awaits — the first `subscribe_state_change()` raises:

```
File ".../libdeye/mqtt_client.py", line 266, in subscribe_state_change
    self._topic,
AttributeError: 'DeyeFogMqttClient' object has no attribute '_topic'
```

and the entry sits in **Failed setup, will retry** indefinitely.

### This is reachable today

My **DYD-P40** reports `platform = 3` — a value `DeyeIotPlatform` doesn't define (`Classic = 1`, `Fog = 2`) — on `protocol_version = combo_V1.0`, product id `d71936c6951c11f0a8200242ac480009`.

### The fix

Make the connect guard the complement of the routing condition, so the two stay in step by construction. I deliberately did **not** add `platform 3` to the enum: this way the guard cannot drift from the routing again, and it stays correct if Deye introduces a platform 4, without anyone having to enumerate the values.

### Verification

Against the live platform-3 device, once the client is actually connected:

- `fogmqttinfo/` → `mqtt-fog-app.deye.com.cn:8883`
- `get/properties/` → real fields (`CurrentEnvironmentalHumidity`, `CurrentAmbientTemperature`, `Mode`, `Fan`, `CompressorStatus`, `KeyLock`, `FilterRuntimePercentage`, …)
- `connect()` sets `_topic`, subscribing raises nothing, an availability push arrives
- state flows into Home Assistant and updates live (humidity tracking 64↔65 %RH, temperature 23 °C)

So the Fog path serves this platform correctly — the connect guard was the only thing in the way.

There is a second, independent gap for this model in `libdeye` (`WindSpeed = 5` is outside `DeyeFanSpeed`, and the product has no `PRODUCT_FEATURE_CONFIG` entry); I've opened a separate PR there.