### PR TITLE
fix: replace deprecated PERCENTAGE with UnitOfRatio.PERCENTAGE

### DIFF
--- a/custom_components/deye_dehumidifier/sensor.py
+++ b/custom_components/deye_dehumidifier/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import UnitOfRatio, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -52,7 +52,7 @@ class DeyeHumiditySensor(DeyeEntity, SensorEntity):
     _attr_translation_key = "humidity"
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = UnitOfRatio.PERCENTAGE
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Home Assistant 2026.7 deprecates the `PERCENTAGE` constant in favor of `UnitOfRatio.PERCENTAGE`, with removal planned for 2027.8.

This updates the humidity sensor in `custom_components/deye_dehumidifier/sensor.py`:

- `_attr_native_unit_of_measurement` now uses `UnitOfRatio.PERCENTAGE` from `homeassistant.const`
- Unused `PERCENTAGE` import is removed

The unit string remains `"%"`, so no entity state migration is required. `hacs.json` is left unchanged; a separate PR handles the minimum Home Assistant version.

## Test plan

- [x] Diff is limited to the humidity sensor unit constant and its import
- [x] `UnitOfRatio.PERCENTAGE` is `"%"` in Home Assistant 2026.7+ `homeassistant.const` (same value as the legacy `PERCENTAGE` alias)
- [x] `ruff check` / `ruff format --check` on `sensor.py`
- [x] hassfest, HACS, and check-versions succeeded on this PR
- [ ] `uv run mypy .` currently fails against the repo pin `homeassistant==2026.3.0` (`Module "homeassistant.const" has no attribute "UnitOfRatio"`). `UnitOfRatio` was added in HA 2026.7. This PR does not bump the minimum HA version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant swap on one sensor attribute with no logic or data-handling changes.
> 
> **Overview**
> Updates the humidity sensor to use Home Assistant’s **`UnitOfRatio.PERCENTAGE`** instead of the deprecated **`PERCENTAGE`** constant (deprecated in 2026.7, removal in 2027.8). The import from `homeassistant.const` is switched accordingly; behavior and the displayed unit (`%`) are unchanged, so no entity migration is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cfa26d6471f88826bb4e0ed2f9ad4eaa28a6a5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->