### PR TITLE
feat: modernize reauth helpers and add reconfigure flow

### DIFF
--- a/custom_components/deye_dehumidifier/config_flow.py
+++ b/custom_components/deye_dehumidifier/config_flow.py
@@ -11,11 +11,7 @@ from libdeye.cloud_api import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow as ConfigFlowBase,
-    ConfigFlowResult,
-)
+from homeassistant.config_entries import ConfigFlow as ConfigFlowBase, ConfigFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -68,8 +64,6 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
 
     VERSION = 1
 
-    _reauth_entry: ConfigEntry | None
-
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -99,17 +93,14 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         self, user_input: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Dialog that informs the user that reauth is required."""
-        assert self._reauth_entry
-        username = self._reauth_entry.data[CONF_USERNAME]
+        reauth_entry = self._get_reauth_entry()
+        username = reauth_entry.data[CONF_USERNAME]
         if user_input is None:
             return self.async_show_form(
                 step_id="reauth_confirm",
@@ -128,9 +119,42 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
                 description_placeholders={"username": username},
             )
 
-        self.hass.config_entries.async_update_entry(
-            self._reauth_entry,
-            data=result["data"],
+        return self.async_update_reload_and_abort(
+            reauth_entry,
+            data_updates={
+                CONF_PASSWORD: result["data"][CONF_PASSWORD],
+                CONF_AUTH_TOKEN: result["data"][CONF_AUTH_TOKEN],
+            },
         )
-        await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
-        return self.async_abort(reason="reauth_successful")
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow initialized by the user."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        username = reconfigure_entry.data[CONF_USERNAME]
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=STEP_REAUTH_DATA_SCHEMA,
+                description_placeholders={"username": username},
+            )
+        user_input[CONF_USERNAME] = username
+        result = await validate_input(self.hass, user_input)
+        if "errors" in result:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=self.add_suggested_values_to_schema(
+                    STEP_REAUTH_DATA_SCHEMA, user_input
+                ),
+                errors=result["errors"],
+                description_placeholders={"username": username},
+            )
+
+        return self.async_update_reload_and_abort(
+            reconfigure_entry,
+            data_updates={
+                CONF_PASSWORD: result["data"][CONF_PASSWORD],
+                CONF_AUTH_TOKEN: result["data"][CONF_AUTH_TOKEN],
+            },
+        )

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -3,7 +3,8 @@
   "config": {
     "abort": {
       "already_configured_account": "Account is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Re-configuration was successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",
@@ -14,6 +15,13 @@
       "reauth_confirm": {
         "title": "Reauthenticate Integration",
         "description": "Please reenter the password for: {username}",
+        "data": {
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Integration",
+        "description": "Please enter the new password for: {username}",
         "data": {
           "password": "Password"
         }

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -3,7 +3,8 @@
   "config": {
     "abort": {
       "already_configured_account": "Conta já configurada",
-      "reauth_successful": "A reautenticação bem efetuada"
+      "reauth_successful": "A reautenticação bem efetuada",
+      "reconfigure_successful": "A reconfiguração foi efetuada com sucesso"
     },
     "error": {
       "cannot_connect": "Falha na ligação",
@@ -14,6 +15,13 @@
       "reauth_confirm": {
         "title": "Reutanticação na integração",
         "description": "Inserir a senha para o utilizador: {username}",
+        "data": {
+          "password": "Senha"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurar integração",
+        "description": "Inserir a nova senha para o utilizador: {username}",
         "data": {
           "password": "Senha"
         }

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -3,7 +3,8 @@
   "config": {
     "abort": {
       "already_configured_account": "Tài khoản đã được cấu hình",
-      "reauth_successful": "Xác thực lại thành công"
+      "reauth_successful": "Xác thực lại thành công",
+      "reconfigure_successful": "Cấu hình lại thành công"
     },
     "error": {
       "cannot_connect": "Không thể kết nối",
@@ -14,6 +15,13 @@
       "reauth_confirm": {
         "title": "Xác thực lại tích hợp",
         "description": "Vui lòng nhập lại mật khẩu cho tài khoản {username}",
+        "data": {
+          "password": "Mật khẩu"
+        }
+      },
+      "reconfigure": {
+        "title": "Cấu hình lại tích hợp",
+        "description": "Vui lòng nhập mật khẩu mới cho tài khoản {username}",
         "data": {
           "password": "Mật khẩu"
         }

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -3,7 +3,8 @@
   "config": {
     "abort": {
       "already_configured_account": "账户已经配置过了",
-      "reauth_successful": "重新认证成功"
+      "reauth_successful": "重新认证成功",
+      "reconfigure_successful": "重新配置成功"
     },
     "error": {
       "cannot_connect": "连接失败",
@@ -14,6 +15,13 @@
       "reauth_confirm": {
         "title": "使集成重新进行身份认证",
         "description": "请重新输入账号 {username} 的密码",
+        "data": {
+          "password": "密码"
+        }
+      },
+      "reconfigure": {
+        "title": "重新配置集成",
+        "description": "请输入账号 {username} 的新密码",
         "data": {
           "password": "密码"
         }

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -3,7 +3,8 @@
   "config": {
     "abort": {
       "already_configured_account": "帳號已經設定完成",
-      "reauth_successful": "重新認證成功"
+      "reauth_successful": "重新認證成功",
+      "reconfigure_successful": "重新設定成功"
     },
     "error": {
       "cannot_connect": "連線失敗",
@@ -14,6 +15,13 @@
       "reauth_confirm": {
         "title": "重新認證整合",
         "description": "請重新輸入帳號 {username} 的密碼",
+        "data": {
+          "password": "密碼"
+        }
+      },
+      "reconfigure": {
+        "title": "重新設定整合",
+        "description": "請輸入帳號 {username} 的新密碼",
         "data": {
           "password": "密碼"
         }


### PR DESCRIPTION
## Summary

Modernize the Deye Dehumidifier config flow to the Home Assistant 2024.4 / 2024.10 reauth and reconfigure helpers.

- Drop the cached `self._reauth_entry` class attribute and `hass.config_entries.async_get_entry(self.context["entry_id"])` lookup. Each step now reads a local `reauth_entry` / `reconfigure_entry` via `_get_reauth_entry()` / `_get_reconfigure_entry()`.
- Successful reauth uses `async_update_reload_and_abort(..., data_updates={password, auth_token})` instead of a full `data` replace plus a manual `async_reload`.
- Add `async_step_reconfigure` so the user can change the Deye Smart password without waiting for an auth failure. Username stays immutable; only password and the resulting `auth_token` are updated. Abort reason is the helper default `reconfigure_successful`.
- Translations (en, zh-Hans, zh-Hant, vi-VN, pt-PT): `abort.reconfigure_successful` plus a `reconfigure` step title/description/`data.password`.

This does **not** migrate `runtime_data` or other features.

## Test plan

- [x] Logic review of reauth/reconfigure steps (username frozen, `data_updates` only password + auth_token)
- [x] `python3.13 -m compileall custom_components/deye_dehumidifier` — bytecode compiled cleanly
- [x] AST/source checks (35/35): no `_reauth_entry` cache, no `async_get_entry` / `async_update_entry` / `async_reload`, local `_get_reauth_entry()` / `_get_reconfigure_entry()`, `data_updates` is `CONF_PASSWORD` + `CONF_AUTH_TOKEN` only, all five translation files have `abort.reconfigure_successful` and a password-only `reconfigure` step
- [x] `ruff check` / `ruff format --check` on `config_flow.py`
- [ ] Full `uv run mypy .` / `uv run pre-commit` — not run locally (environment has Python 3.13; this repo requires 3.14 for Home Assistant 2026.3). Relying on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential storage and config entry reload on reauth/reconfigure; scope is limited to config flow and translations with no runtime device logic changes.
> 
> **Overview**
> Updates the Deye Dehumidifier **config flow** to Home Assistant’s current reauth/reconfigure patterns and adds a user-initiated password change path.
> 
> **Reauth** no longer caches `_reauth_entry` or manually reloads the entry. It resolves the entry via `_get_reauth_entry()` and finishes with `async_update_reload_and_abort`, updating only `password` and `auth_token` after validation.
> 
> **Reconfigure** adds `async_step_reconfigure` so users can change the Deye Smart password without waiting for an auth failure. Username stays fixed; the same password form and validation apply, with `_get_reconfigure_entry()` and the same partial `data_updates`.
> 
> **Translations** (en, pt-PT, vi-VN, zh-Hans, zh-Hant) add `abort.reconfigure_successful` and a `reconfigure` step (title, description, password label).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b622b00c4c8e59b94e119faeb363683bcf7bd96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->