### PR TITLE
Set PARALLEL_UPDATES = 0 on coordinator entity platforms

### DIFF
--- a/custom_components/deye_dehumidifier/binary_sensor.py
+++ b/custom_components/deye_dehumidifier/binary_sensor.py
@@ -16,6 +16,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import DATA_KEY, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -24,9 +27,11 @@ async def async_setup_entry(
 ) -> None:
     """Add sensors for passed config_entry in HA."""
     data = hass.data[DATA_KEY][config_entry.entry_id]
-    for device in data.device_list:
-        async_add_entities(
-            [
+    async_add_entities(
+        [
+            sensor
+            for device in data.device_list
+            for sensor in (
                 DeyeWaterTankBinarySensor(
                     data.coordinator_map[device["device_id"]],
                     device,
@@ -35,8 +40,9 @@ async def async_setup_entry(
                     data.coordinator_map[device["device_id"]],
                     device,
                 ),
-            ]
-        )
+            )
+        ]
+    )
 
 
 class DeyeWaterTankBinarySensor(DeyeEntity, BinarySensorEntity):

--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -17,6 +17,9 @@ from homeassistant.util.percentage import (
 from . import DATA_KEY, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -25,17 +28,16 @@ async def async_setup_entry(
 ) -> None:
     """Add fans for passed config_entry in HA."""
     data = hass.data[DATA_KEY][config_entry.entry_id]
-    for device in data.device_list:
-        feature_config = get_product_feature_config(device["product_id"])
-        if len(feature_config["fan_speed"]) > 0:
-            async_add_entities(
-                [
-                    DeyeFan(
-                        data.coordinator_map[device["device_id"]],
-                        device,
-                    )
-                ]
+    async_add_entities(
+        [
+            DeyeFan(
+                data.coordinator_map[device["device_id"]],
+                device,
             )
+            for device in data.device_list
+            if len(get_product_feature_config(device["product_id"])["fan_speed"]) > 0
+        ]
+    )
 
 
 class DeyeFan(DeyeEntity, FanEntity):

--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -28,6 +28,9 @@ MODE_MANUAL_PURIFIER = "manual_purifier"
 MODE_SLEEP_PURIFIER = "sleep_purifier"
 MODE_AUTO_PURIFIER = "auto_purifier"
 
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -36,13 +39,15 @@ async def async_setup_entry(
 ) -> None:
     """Add dehumidifiers for passed config_entry in HA."""
     data = hass.data[DATA_KEY][config_entry.entry_id]
-
-    for device in data.device_list:
-        deye_dehumidifier = DeyeDehumidifier(
-            data.coordinator_map[device["device_id"]],
-            device,
-        )
-        async_add_entities([deye_dehumidifier])
+    async_add_entities(
+        [
+            DeyeDehumidifier(
+                data.coordinator_map[device["device_id"]],
+                device,
+            )
+            for device in data.device_list
+        ]
+    )
 
 
 class DeyeDehumidifier(DeyeEntity, HumidifierEntity):

--- a/custom_components/deye_dehumidifier/sensor.py
+++ b/custom_components/deye_dehumidifier/sensor.py
@@ -17,6 +17,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import DATA_KEY, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -25,10 +28,11 @@ async def async_setup_entry(
 ) -> None:
     """Add sensors for passed config_entry in HA."""
     data = hass.data[DATA_KEY][config_entry.entry_id]
-
-    for device in data.device_list:
-        async_add_entities(
-            [
+    async_add_entities(
+        [
+            sensor
+            for device in data.device_list
+            for sensor in (
                 DeyeHumiditySensor(
                     data.coordinator_map[device["device_id"]],
                     device,
@@ -37,8 +41,9 @@ async def async_setup_entry(
                     data.coordinator_map[device["device_id"]],
                     device,
                 ),
-            ]
-        )
+            )
+        ]
+    )
 
 
 class DeyeHumiditySensor(DeyeEntity, SensorEntity):

--- a/custom_components/deye_dehumidifier/switch.py
+++ b/custom_components/deye_dehumidifier/switch.py
@@ -43,6 +43,9 @@ _FEATURE_FLAG_SWITCHES = (
     ),
 )
 
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
 
 def _feature_flag_enabled(
     feature_config: DeyeProductConfig,
@@ -62,13 +65,14 @@ async def async_setup_entry(
     """Add switches for passed config_entry in HA."""
     data = hass.data[DATA_KEY][config_entry.entry_id]
 
+    entities: list[SwitchEntity] = []
     for device in data.device_list:
         feature_config = get_product_feature_config(device["product_id"])
         coordinator = data.coordinator_map[device["device_id"]]
-        entities: list[SwitchEntity] = [
+        entities.extend(
             DeyeConfigSwitch(coordinator, device, spec)
             for spec in _ALWAYS_ON_FLAG_SWITCHES
-        ]
+        )
         entities.append(
             DeyeContinuousSwitch(
                 coordinator,
@@ -81,7 +85,7 @@ async def async_setup_entry(
             for spec in _FEATURE_FLAG_SWITCHES
             if _feature_flag_enabled(feature_config, spec)
         )
-        async_add_entities(entities)
+    async_add_entities(entities)
 
 
 class DeyeConfigSwitch(DeyeEntity, SwitchEntity):


### PR DESCRIPTION
## Summary

Implements the Home Assistant [silver quality-scale `parallel-updates`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/) rule.

All coordinator-backed entity platforms now declare `PARALLEL_UPDATES = 0` so Home Assistant does not parallel-poll entities (updates already go through `DeyeDataUpdateCoordinator`):

- `humidifier.py`
- `sensor.py`
- `switch.py`
- `binary_sensor.py`
- `fan.py`

Platform setup also calls `async_add_entities` once with a collected list instead of once per device. In `switch.py`, entities are accumulated across devices and registered in a single call. Entity construction and feature gates are unchanged.

## Test plan

- [x] AST: each platform defines `PARALLEL_UPDATES = 0` and has exactly one `async_add_entities` call, not inside the device loop
- [x] `ruff check` / `ruff format --check` on the five platform files
- [x] `python3 -m py_compile` on the five platform files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Setup-only and HA integration-metadata changes; entity types, coordinators, and feature gates are the same.
> 
> **Overview**
> Adds **`PARALLEL_UPDATES = 0`** on all coordinator-backed platforms (`humidifier`, `sensor`, `switch`, `binary_sensor`, `fan`) so Home Assistant does not run parallel per-entity polls—polling stays on **`DeyeDataUpdateCoordinator`**, matching the silver quality-scale **parallel-updates** rule.
> 
> **`async_setup_entry`** now registers entities in **one** `async_add_entities` call per platform (list comprehensions / nested comprehensions) instead of calling it inside the per-device loop. **`switch.py`** builds a single `entities` list across all devices with `extend`/`append`, then registers once; fan feature gating and switch product flags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9ec35e0498d99f9ab302a4ce71d275e655b226. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->