### PR TITLE
Use built-in humidifier MODE_NORMAL and 5% humidity step

### DIFF
--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -76,7 +76,7 @@ class DeyeDehumidifier(DeyeEntity, HumidifierEntity):
         self._attr_min_humidity = feature_config["min_target_humidity"]
         self._attr_max_humidity = feature_config["max_target_humidity"]
         # Deye UIs and official apps step target humidity in 5% increments.
-        self._attr_target_humidity_step = 5
+        self._attr_target_humidity_step = 5.0
         self._attr_entity_picture = device["picture_v3"] or device["product_icon"]
 
     @property

--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -4,13 +4,14 @@ from typing import Any, override
 
 from libdeye.cloud_api import DeyeApiResponseDeviceInfo
 from libdeye.const import DeyeDeviceMode, get_product_feature_config
-from libdeye.device_state import DeyeDeviceState
 
-from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
-from homeassistant.components.humidifier.const import (
+from homeassistant.components.humidifier import (
     MODE_AUTO,
+    MODE_NORMAL,
     MODE_SLEEP,
     HumidifierAction,
+    HumidifierDeviceClass,
+    HumidifierEntity,
     HumidifierEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -20,7 +21,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import DATA_KEY, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
-MODE_MANUAL = "manual"
 MODE_AIR_PURIFIER = "air_purifier"
 MODE_CLOTHES_DRYER = "clothes_dryer"
 MODE_TURBO = "turbo"
@@ -75,12 +75,9 @@ class DeyeDehumidifier(DeyeEntity, HumidifierEntity):
         )
         self._attr_min_humidity = feature_config["min_target_humidity"]
         self._attr_max_humidity = feature_config["max_target_humidity"]
+        # Deye UIs and official apps step target humidity in 5% increments.
+        self._attr_target_humidity_step = 5
         self._attr_entity_picture = device["picture_v3"] or device["product_icon"]
-
-    @property
-    def get_device_state(self) -> DeyeDeviceState:
-        """Return the current desired device state."""
-        return self.coordinator.data.state
 
     @property
     @override
@@ -159,7 +156,7 @@ def deye_mode_to_hass_mode(mode: DeyeDeviceMode) -> str:
         return MODE_SLEEP_PURIFIER
     if mode == DeyeDeviceMode.AUTO_PURIFIER_MODE:
         return MODE_AUTO_PURIFIER
-    return MODE_MANUAL
+    return MODE_NORMAL
 
 
 def hass_mode_to_deye_mode(mode: str) -> DeyeDeviceMode:

--- a/custom_components/deye_dehumidifier/icons.json
+++ b/custom_components/deye_dehumidifier/icons.json
@@ -5,7 +5,7 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "mdi:cursor-pointer",
+              "normal": "mdi:cursor-pointer",
               "auto": "mdi:refresh-auto",
               "sleep": "mdi:power-sleep",
               "air_purifier": "mdi:air-purifier",

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -41,7 +41,6 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "Manual",
               "auto": "Automatic",
               "sleep": "Sleep",
               "air_purifier": "Purify",

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -41,6 +41,7 @@
         "state_attributes": {
           "mode": {
             "state": {
+              "normal": "Normal",
               "auto": "Automatic",
               "sleep": "Sleep",
               "air_purifier": "Purify",

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -41,7 +41,6 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "Manual",
               "auto": "Automático",
               "sleep": "Sono",
               "air_purifier": "Purificar",

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -41,6 +41,7 @@
         "state_attributes": {
           "mode": {
             "state": {
+              "normal": "Normal",
               "auto": "Automático",
               "sleep": "Sono",
               "air_purifier": "Purificar",

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -41,6 +41,7 @@
         "state_attributes": {
           "mode": {
             "state": {
+              "normal": "Bình thường",
               "auto": "Tự động",
               "sleep": "Ngủ",
               "air_purifier": "Làm sạch",

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -41,7 +41,6 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "Thủ công",
               "auto": "Tự động",
               "sleep": "Ngủ",
               "air_purifier": "Làm sạch",

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -41,6 +41,7 @@
         "state_attributes": {
           "mode": {
             "state": {
+              "normal": "正常",
               "auto": "自动",
               "sleep": "睡眠",
               "air_purifier": "净化",

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -41,7 +41,6 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "手动",
               "auto": "自动",
               "sleep": "睡眠",
               "air_purifier": "净化",

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -41,6 +41,7 @@
         "state_attributes": {
           "mode": {
             "state": {
+              "normal": "正常",
               "auto": "自動",
               "sleep": "睡眠",
               "air_purifier": "淨化",

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -41,7 +41,6 @@
         "state_attributes": {
           "mode": {
             "state": {
-              "manual": "手動",
               "auto": "自動",
               "sleep": "睡眠",
               "air_purifier": "淨化",


### PR DESCRIPTION
## Summary

Polish the humidifier platform to use Home Assistant's built-in mode constants and a Deye-typical target humidity step. Other platforms are unchanged.

- Import `MODE_AUTO`, `MODE_SLEEP`, `MODE_NORMAL`, `HumidifierAction`, `HumidifierEntityFeature`, `HumidifierDeviceClass`, and `HumidifierEntity` from `homeassistant.components.humidifier` (the package), not `homeassistant.components.humidifier.const`.
- Replace the custom `MODE_MANUAL = "manual"` with built-in `MODE_NORMAL` (`"normal"`) in `deye_mode_to_hass_mode` / `hass_mode_to_deye_mode`.
- Drop the unused `get_device_state` helper (and its `DeyeDeviceState` import).
- Set `_attr_target_humidity_step = 5.0`. libdeye treats humidity as whole percents, with a default range of 25–80% and typical values in 5% increments; Deye UIs also step by 5%.
- Keep `normal` labels in `en`, `zh-Hans`, `zh-Hant`, `pt-PT`, and `vi-VN` so the custom humidifier entity map still localizes `MODE_NORMAL` (custom integrations do not fall back to core humidifier strings). Remove the old `manual` keys. Custom modes such as `manual_purifier` are unchanged.
- Point `icons.json` at `normal` instead of `manual`.

## Breaking change

**Humidifier mode `manual` is now `normal`.**

Automations, scripts, scenes, and templates that check or set the dehumidifier mode must be updated:

```yaml
# Before
action: humidifier.set_mode
target:
  entity_id: humidifier.your_deye_dehumidifier
data:
  mode: manual

# After
action: humidifier.set_mode
target:
  entity_id: humidifier.your_deye_dehumidifier
data:
  mode: normal
```

The entity `mode` attribute and `available_modes` now expose `normal`. Home Assistant will reject `humidifier.set_mode` with `manual` because that value is no longer advertised. The Deye device still uses its native manual mode; only the Home Assistant mode string changed.

The custom `manual_purifier` mode is **not** part of this rename.

## Test plan

- [x] AST/import check: humidifier constants come from the package; `MODE_MANUAL` and `get_device_state` are gone; `_attr_target_humidity_step = 5.0`.
- [x] Mode mapping: `DeyeDeviceMode.MANUAL_MODE` ↔ `MODE_NORMAL` (`"normal"`); other modes including `manual_purifier` still round-trip.
- [x] Translations define `normal` (not `manual`); `icons.json` keys `normal`.
- [x] `ruff check` / `ruff format --check` on `humidifier.py`.
- [ ] After merge: in Home Assistant, confirm the humidifier entity lists `normal` and the target humidity slider steps by 5%.
