### PR TITLE
feat: raise translated HomeAssistantError on entity command failures

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -15,7 +15,11 @@ from libdeye.cloud_api import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -39,6 +43,25 @@ _LOGGER = logging.getLogger(__name__)
 DATA_KEY: HassKey[dict[str, ConfigEntryData]] = HassKey(DOMAIN)
 
 _DEHUMIDIFIER_PRODUCT_TYPES = {"dehumidifier", "除湿机", "其他"}
+
+
+def _wrap_command_exception(err: Exception) -> HomeAssistantError:
+    """Convert a device command failure into a translated HomeAssistantError."""
+    if isinstance(err, DeyeCloudApiCannotConnectError):
+        return HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="command_cannot_connect",
+        )
+    if isinstance(err, DeyeCloudApiInvalidAuthError):
+        return HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="command_invalid_auth",
+        )
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="command_failed",
+        translation_placeholders={"error": str(err) or type(err).__name__},
+    )
 
 
 @dataclass
@@ -143,11 +166,17 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
 
     async def _publish_command(self) -> None:
         """Publish commands to the device."""
-        command = self.coordinator.data.state.to_command()
-        await self.coordinator.device.apply(
-            command, baseline=self.coordinator.data.reported_state
-        )
-        self.coordinator.sync_reported_state_after_publish()
+        try:
+            command = self.coordinator.data.state.to_command()
+            await self.coordinator.device.apply(
+                command, baseline=self.coordinator.data.reported_state
+            )
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise _wrap_command_exception(err) from err
+        else:
+            self.coordinator.sync_reported_state_after_publish()
 
     async def publish_command_from_current_state(self) -> None:
         """Publish a command generated from the current desired state.
@@ -156,7 +185,12 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
         """
         self.coordinator.mute_state_update_for_a_while()
         self.coordinator.async_update_listeners()
-        await self._debounced_publish_command.async_call()
+        try:
+            await self._debounced_publish_command.async_call()
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise _wrap_command_exception(err) from err
 
     @property
     @override

--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -166,8 +166,8 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
 
     async def _publish_command(self) -> None:
         """Publish commands to the device."""
+        command = self.coordinator.data.state.to_command()
         try:
-            command = self.coordinator.data.state.to_command()
             await self.coordinator.device.apply(
                 command, baseline=self.coordinator.data.reported_state
             )
@@ -175,8 +175,7 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
             raise
         except Exception as err:
             raise _wrap_command_exception(err) from err
-        else:
-            self.coordinator.sync_reported_state_after_publish()
+        self.coordinator.sync_reported_state_after_publish()
 
     async def publish_command_from_current_state(self) -> None:
         """Publish a command generated from the current desired state.
@@ -185,12 +184,7 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
         """
         self.coordinator.mute_state_update_for_a_while()
         self.coordinator.async_update_listeners()
-        try:
-            await self._debounced_publish_command.async_call()
-        except HomeAssistantError:
-            raise
-        except Exception as err:
-            raise _wrap_command_exception(err) from err
+        await self._debounced_publish_command.async_call()
 
     @property
     @override

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -114,5 +114,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_cannot_connect": {
+      "message": "Failed to connect to the Deye cloud while sending a command"
+    },
+    "command_invalid_auth": {
+      "message": "Authentication failed while sending a command to the device"
+    },
+    "command_failed": {
+      "message": "Failed to send command to the device: {error}"
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -114,5 +114,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_cannot_connect": {
+      "message": "Falha na ligação à nuvem Deye ao enviar um comando"
+    },
+    "command_invalid_auth": {
+      "message": "Falha na autenticação ao enviar um comando para o dispositivo"
+    },
+    "command_failed": {
+      "message": "Falha ao enviar comando para o dispositivo: {error}"
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -114,5 +114,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_cannot_connect": {
+      "message": "Không thể kết nối tới đám mây Deye khi gửi lệnh"
+    },
+    "command_invalid_auth": {
+      "message": "Xác thực thất bại khi gửi lệnh tới thiết bị"
+    },
+    "command_failed": {
+      "message": "Không gửi được lệnh tới thiết bị: {error}"
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -114,5 +114,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_cannot_connect": {
+      "message": "向设备发送指令时无法连接德业云"
+    },
+    "command_invalid_auth": {
+      "message": "向设备发送指令时身份认证失败"
+    },
+    "command_failed": {
+      "message": "向设备发送指令失败：{error}"
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -114,5 +114,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "command_cannot_connect": {
+      "message": "向裝置傳送指令時無法連線德業雲"
+    },
+    "command_invalid_auth": {
+      "message": "向裝置傳送指令時身份驗證失敗"
+    },
+    "command_failed": {
+      "message": "向裝置傳送指令失敗：{error}"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Home Assistant quality scale: **action-exceptions** and **exception-translations**.

Entity service actions (humidifier, fan, and switch) all publish through `DeyeEntity._publish_command` / `publish_command_from_current_state`. MQTT/API failures from `DeyeDevice.apply()` previously bubbled as raw library exceptions (or were untranslated). They are now wrapped in `HomeAssistantError` with `translation_domain=DOMAIN` and a `translation_key`:

- `command_cannot_connect` — `DeyeCloudApiCannotConnectError`
- `command_invalid_auth` — `DeyeCloudApiInvalidAuthError`
- `command_failed` — other publish errors, with `{error}` placeholder

Existing `HomeAssistantError` instances are re-raised unchanged. The original exception is kept as `__cause__`. Reported state is only synced after a successful publish.

`exceptions` keys are added to all translation files (`en`, `zh-Hans`, `zh-Hant`, `vi-VN`, `pt-PT`).

Config flow UX is unchanged: `validate_input` still maps `cannot_connect` / `invalid_auth` / unexpected errors onto the form (`config.error.*`) instead of aborting the flow. Coordinator poll failures are out of scope.

## Test plan

- [x] Helper wrapping: connect / auth / generic MQTT-style errors become `HomeAssistantError` with the expected `translation_key` and placeholders; cause is preserved; success still syncs reported state
- [x] All five translation files define the same `exceptions` keys; `{error}` is only used on `command_failed`
- [x] `uv run ruff check` / `ruff format --check`
- [x] `uv run mypy .`
- [x] `uv run pylint custom_components scripts`
- [x] `uv run pre-commit run --all-files`
- [ ] CI (hassfest, HACS, lint/type-check) on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error handling around entity command publishing; no change to config flow or coordinator polling behavior.
> 
> **Overview**
> Entity actions that publish device state through `DeyeEntity._publish_command` now surface failures as translated `HomeAssistantError` instead of raw library exceptions.
> 
> A new `_wrap_command_exception` maps `DeyeCloudApiCannotConnectError` and `DeyeCloudApiInvalidAuthError` to `command_cannot_connect` and `command_invalid_auth`; other errors use `command_failed` with an `{error}` placeholder. Existing `HomeAssistantError` instances pass through unchanged, and the original exception remains as `__cause__`. **Reported state is only synced after a successful publish.**
> 
> Matching `exceptions` entries were added in `en`, `pt-PT`, `vi-VN`, `zh-Hans`, and `zh-Hant` translation files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5f838b1a32e548a60692372c9e3080aa6a5050. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->