### PR TITLE
feat: expose named Deye fan speeds as Home Assistant preset modes

### DIFF
--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -20,6 +20,36 @@ from .data_coordinator import DeyeDataUpdateCoordinator
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
+PRESET_MODE_LOW = "low"
+PRESET_MODE_MEDIUM = "medium"
+PRESET_MODE_HIGH = "high"
+PRESET_MODE_FULL = "full"
+PRESET_MODE_AUTO = "auto"
+
+_DEYE_FAN_SPEED_TO_PRESET: dict[DeyeFanSpeed, str] = {
+    DeyeFanSpeed.LOW: PRESET_MODE_LOW,
+    DeyeFanSpeed.MIDDLE: PRESET_MODE_MEDIUM,
+    DeyeFanSpeed.HIGH: PRESET_MODE_HIGH,
+    DeyeFanSpeed.FULL: PRESET_MODE_FULL,
+    DeyeFanSpeed.AUTO: PRESET_MODE_AUTO,
+}
+
+_PRESET_TO_DEYE_FAN_SPEED: dict[str, DeyeFanSpeed] = {
+    preset: speed for speed, preset in _DEYE_FAN_SPEED_TO_PRESET.items()
+}
+
+
+def deye_fan_speed_to_preset_mode(fan_speed: DeyeFanSpeed) -> str | None:
+    """Map DeyeFanSpeed to a Home Assistant fan preset mode."""
+    return _DEYE_FAN_SPEED_TO_PRESET.get(fan_speed)
+
+
+def preset_mode_to_deye_fan_speed(preset_mode: str) -> DeyeFanSpeed:
+    """Map a Home Assistant fan preset mode to DeyeFanSpeed."""
+    if preset_mode not in _PRESET_TO_DEYE_FAN_SPEED:
+        raise ValueError(f"Invalid preset mode: {preset_mode}")
+    return _PRESET_TO_DEYE_FAN_SPEED[preset_mode]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -60,11 +90,17 @@ class DeyeFan(DeyeEntity, FanEntity):
             FanEntityFeature.SET_SPEED
             | FanEntityFeature.TURN_ON
             | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.PRESET_MODE
         )
         if feature_config["oscillating"]:
             self._attr_supported_features |= FanEntityFeature.OSCILLATE
         self._named_fan_speeds = feature_config["fan_speed"]
         self._attr_speed_count = len(self._named_fan_speeds)
+        self._attr_preset_modes = [
+            _DEYE_FAN_SPEED_TO_PRESET[speed]
+            for speed in self._named_fan_speeds
+            if speed in _DEYE_FAN_SPEED_TO_PRESET
+        ]
 
     @property
     @override
@@ -89,6 +125,12 @@ class DeyeFan(DeyeEntity, FanEntity):
         except ValueError:
             return 0
 
+    @property
+    @override
+    def preset_mode(self) -> str | None:
+        """Return the current named fan speed preset."""
+        return deye_fan_speed_to_preset_mode(self.coordinator.data.state.fan_speed)
+
     @override
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
@@ -107,6 +149,14 @@ class DeyeFan(DeyeEntity, FanEntity):
         await self.publish_command_from_current_state()
 
     @override
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the fan speed from a named preset."""
+        self.coordinator.data.state.fan_speed = preset_mode_to_deye_fan_speed(
+            preset_mode
+        )
+        await self.publish_command_from_current_state()
+
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -115,7 +165,11 @@ class DeyeFan(DeyeEntity, FanEntity):
     ) -> None:
         """Turn on the fan."""
         self.coordinator.data.state.power_switch = True
-        if percentage is not None:
+        if preset_mode is not None:
+            self.coordinator.data.state.fan_speed = preset_mode_to_deye_fan_speed(
+                preset_mode
+            )
+        elif percentage is not None:
             fan_speed = DeyeFanSpeed(
                 percentage_to_ordered_list_item(self._named_fan_speeds, percentage)
             )

--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -125,11 +125,20 @@ class DeyeFan(DeyeEntity, FanEntity):
         except ValueError:
             return 0
 
+    def _preset_to_supported_speed(self, preset_mode: str) -> DeyeFanSpeed:
+        """Map a preset to a fan speed advertised by this model."""
+        if preset_mode not in (self._attr_preset_modes or []):
+            raise ValueError(f"Unsupported preset mode: {preset_mode}")
+        return preset_mode_to_deye_fan_speed(preset_mode)
+
     @property
     @override
     def preset_mode(self) -> str | None:
         """Return the current named fan speed preset."""
-        return deye_fan_speed_to_preset_mode(self.coordinator.data.state.fan_speed)
+        preset = deye_fan_speed_to_preset_mode(self.coordinator.data.state.fan_speed)
+        if preset is None or preset not in (self._attr_preset_modes or []):
+            return None
+        return preset
 
     @override
     async def async_oscillate(self, oscillating: bool) -> None:
@@ -142,6 +151,7 @@ class DeyeFan(DeyeEntity, FanEntity):
         """Set the speed of the fan, as a percentage."""
         if percentage == 0:
             await self.async_turn_off()
+            return
         fan_speed = DeyeFanSpeed(
             percentage_to_ordered_list_item(self._named_fan_speeds, percentage)
         )
@@ -151,7 +161,7 @@ class DeyeFan(DeyeEntity, FanEntity):
     @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the fan speed from a named preset."""
-        self.coordinator.data.state.fan_speed = preset_mode_to_deye_fan_speed(
+        self.coordinator.data.state.fan_speed = self._preset_to_supported_speed(
             preset_mode
         )
         await self.publish_command_from_current_state()
@@ -166,7 +176,7 @@ class DeyeFan(DeyeEntity, FanEntity):
         """Turn on the fan."""
         self.coordinator.data.state.power_switch = True
         if preset_mode is not None:
-            self.coordinator.data.state.fan_speed = preset_mode_to_deye_fan_speed(
+            self.coordinator.data.state.fan_speed = self._preset_to_supported_speed(
                 preset_mode
             )
         elif percentage is not None:

--- a/custom_components/deye_dehumidifier/icons.json
+++ b/custom_components/deye_dehumidifier/icons.json
@@ -60,6 +60,21 @@
         }
       }
     },
+    "fan": {
+      "fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "mdi:fan-speed-1",
+              "medium": "mdi:fan-speed-2",
+              "high": "mdi:fan-speed-3",
+              "full": "mdi:fan",
+              "auto": "mdi:fan-auto"
+            }
+          }
+        }
+      }
+    },
     "binary_sensor": {
       "water_tank": {
         "default": "mdi:beer",

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -100,7 +100,18 @@
     },
     "fan": {
       "fan": {
-        "name": "Wind Speed"
+        "name": "Wind Speed",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "Low",
+              "medium": "Medium",
+              "high": "High",
+              "full": "Full",
+              "auto": "Auto"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -100,7 +100,18 @@
     },
     "fan": {
       "fan": {
-        "name": "Velocidade do vento"
+        "name": "Velocidade do vento",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "Baixa",
+              "medium": "Média",
+              "high": "Alta",
+              "full": "Máxima",
+              "auto": "Automático"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -100,7 +100,18 @@
     },
     "fan": {
       "fan": {
-        "name": "Tốc độ gió"
+        "name": "Tốc độ gió",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "Thấp",
+              "medium": "Trung bình",
+              "high": "Cao",
+              "full": "Tối đa",
+              "auto": "Tự động"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -100,7 +100,18 @@
     },
     "fan": {
       "fan": {
-        "name": "风速"
+        "name": "风速",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "低速",
+              "medium": "中速",
+              "high": "高速",
+              "full": "全速",
+              "auto": "自动"
+            }
+          }
+        }
       }
     }
   }

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -100,7 +100,18 @@
     },
     "fan": {
       "fan": {
-        "name": "風速"
+        "name": "風速",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "低速",
+              "medium": "中速",
+              "high": "高速",
+              "full": "全速",
+              "auto": "自動"
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Deye fan speeds are discrete named values (`DeyeFanSpeed`: LOW / MIDDLE / HIGH / FULL / AUTO). Mapping them only to a percentage slider is a poor fit in the Home Assistant UI and in automations that want a named speed.

This adds `FanEntityFeature.PRESET_MODE` on `DeyeFan` while keeping the existing percentage and power APIs:

- **Kept:** `SET_SPEED`, `TURN_ON`, `TURN_OFF`, and `OSCILLATE` when the model supports swing — percentage automations keep working.
- **Added:** `PRESET_MODE` with presets `low`, `medium`, `high`, `full`, and `auto`, filtered to the model's `feature_config["fan_speed"]` (for example W20A3 is `low`/`high`; U20A3 includes `full`; P40 includes `auto`).
- `preset_mode` / `async_set_preset_mode` read and write `state.fan_speed`.
- `async_turn_on(..., preset_mode=...)` applies the named speed.
- Percentage still maps to the nearest named speed via `percentage_to_ordered_list_item`. `percentage == 0` still turns the device off.
- Translations for preset names in `en`, `zh-Hans`, `zh-Hant`, `vi-VN`, and `pt-PT`, plus `icons.json` icons for each preset.

Humidifier and coordinator are unchanged.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` on `fan.py`
- [x] `uv run mypy custom_components/deye_dehumidifier/fan.py`
- [x] `uv run pylint custom_components/deye_dehumidifier/fan.py`
- [x] `uv run pre-commit run --all-files`
- [x] Mapping: LOW/MIDDLE/HIGH/FULL/AUTO ↔ low/medium/high/full/auto; STOPPED → `preset_mode` `None`
- [x] Model presets: W20A3 `low`/`high`; U20A3 `low`/`medium`/`high`/`full`; P40 `low`/`medium`/`high`/`auto`; G25A3 still has `OSCILLATE`
- [x] Features always include `SET_SPEED | TURN_ON | TURN_OFF | PRESET_MODE`
- [x] `async_set_preset_mode("high")` writes `DeyeFanSpeed.HIGH`; `async_set_percentage(100)` writes `FULL`; `percentage == 0` turns off; `async_turn_on(preset_mode="medium")` writes `MIDDLE`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fan-entity-only enhancement; percentage and power behavior stay compatible, with no auth or data-path changes.
> 
> **Overview**
> The **Deye fan** entity now advertises **Home Assistant preset modes** (`low`, `medium`, `high`, `full`, `auto`) in addition to the existing percentage slider, so the UI and automations can target discrete speeds that match the device.
> 
> `DeyeFan` gains `FanEntityFeature.PRESET_MODE`, bidirectional mapping from `DeyeFanSpeed` to preset strings, and `_attr_preset_modes` limited to each model’s `feature_config["fan_speed"]`. **`preset_mode`**, **`async_set_preset_mode`**, and **`async_turn_on(..., preset_mode=...)`** read and write `state.fan_speed` the same way percentage control does. **`async_set_percentage(0)`** now returns immediately after turning off so it no longer also sets a speed.
> 
> Localized preset labels (en, pt-PT, vi-VN, zh-Hans, zh-Hant) and **`icons.json`** entries for each preset complete the UI surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7562fe474b9b1eb363edf479cae2f4f40e781d4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->