### PR TITLE
Add diagnostics platform for config entries and devices

### DIFF
--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -92,7 +92,7 @@ def _platform_label(device: DeyeApiResponseDeviceInfo) -> str:
     """Return Classic / Fog / FogCombo from the device-list platform id."""
     try:
         return DeyeIotPlatform(int(device["platform"])).name
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return _enum_name(device["platform"])
 
 

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -1,5 +1,6 @@
 """Diagnostics support for the Deye Dehumidifier integration."""
 
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any
 
@@ -89,21 +90,17 @@ def _serialize_value(value: object) -> object:
 
 def _platform_label(device: DeyeApiResponseDeviceInfo) -> str:
     """Return Classic / Fog / FogCombo from the device-list platform id."""
-    platform = device["platform"]
-    if isinstance(platform, DeyeIotPlatform):
-        return platform.name
     try:
-        return DeyeIotPlatform(platform).name
-    except ValueError:
-        return str(platform)
+        return DeyeIotPlatform(int(device["platform"])).name
+    except TypeError, ValueError:
+        return _enum_name(device["platform"])
 
 
 def _device_metadata(device: DeyeApiResponseDeviceInfo) -> dict[str, Any]:
     """Return non-secret device-list fields plus Classic/Fog labels."""
+    raw: Mapping[str, Any] = device
     metadata = {
-        key: _serialize_value(device[key])
-        for key in _DEVICE_METADATA_KEYS
-        if key in device
+        key: _serialize_value(raw[key]) for key in _DEVICE_METADATA_KEYS if key in raw
     }
     metadata["platform"] = _platform_label(device)
     metadata["transport"] = _enum_name(transport_for_device(device))

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -90,10 +90,11 @@ def _serialize_value(value: object) -> object:
 
 def _platform_label(device: DeyeApiResponseDeviceInfo) -> str:
     """Return Classic / Fog / FogCombo from the device-list platform id."""
+    platform = device.get("platform")
     try:
-        return DeyeIotPlatform(int(device["platform"])).name
-    except (TypeError, ValueError):
-        return _enum_name(device["platform"])
+        return DeyeIotPlatform(int(platform)).name
+    except TypeError, ValueError:
+        return _enum_name(platform)
 
 
 def _device_metadata(device: DeyeApiResponseDeviceInfo) -> dict[str, Any]:
@@ -131,7 +132,10 @@ def _mqtt_clients_snapshot(client: object) -> list[dict[str, Any]]:
     if not isinstance(mqtt_by_type, dict):
         return []
     snapshots: list[dict[str, Any]] = []
-    for client_cls, mqtt_client in mqtt_by_type.items():
+    for client_cls, mqtt_client in sorted(
+        mqtt_by_type.items(),
+        key=lambda item: getattr(item[0], "__name__", ""),
+    ):
         snapshots.append(
             {
                 "type": getattr(client_cls, "__name__", type(mqtt_client).__name__),
@@ -202,7 +206,8 @@ def _match_device(
     if device_entry.serial_number:
         macs.add(device_entry.serial_number)
     for device in devices:
-        if device["mac"] in macs:
+        mac = device.get("mac")
+        if mac is not None and mac in macs:
             return device
     return None
 

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -1,0 +1,251 @@
+"""Diagnostics support for the Deye Dehumidifier integration."""
+
+from enum import Enum
+from typing import Any
+
+from libdeye.cloud_api import (
+    DeyeApiResponseDeviceInfo,
+    DeyeIotPlatform,
+    transport_for_device,
+)
+from libdeye.device_state import DeyeDeviceState
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from . import DATA_KEY, ConfigEntryData
+from .const import CONF_AUTH_TOKEN, CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from .data_coordinator import DeyeDataUpdateCoordinator
+
+# Redact credentials from config entry data and any nested MQTT payloads.
+TO_REDACT = {
+    CONF_PASSWORD,
+    CONF_AUTH_TOKEN,
+    CONF_USERNAME,
+    "password",
+    "token",
+    "loginname",
+    "auth_token",
+}
+
+# Device-list fields that are useful for support and do not include secrets.
+_DEVICE_METADATA_KEYS = (
+    "device_id",
+    "deviceid",
+    "device_name",
+    "alias",
+    "product_id",
+    "product_name",
+    "product_type",
+    "producttype_id",
+    "platform",
+    "mac",
+    "protocol_version",
+    "online",
+    "role",
+    "is_combo",
+    "gatewaytype",
+    "work_time",
+    "user_count",
+)
+
+_STATE_FIELDS = (
+    "anion_switch",
+    "water_pump_switch",
+    "power_switch",
+    "oscillating_switch",
+    "child_lock_switch",
+    "defrosting",
+    "water_tank_full",
+    "fan_running",
+    "fan_speed",
+    "mode",
+    "target_humidity",
+    "environment_temperature",
+    "environment_humidity",
+    "uv_switch",
+    "prompt_sound",
+    "screen_display",
+    "timed_off_hour",
+)
+
+
+def _enum_name(value: object) -> str:
+    """Return a stable label for an enum or raw platform id."""
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value)
+
+
+def _serialize_value(value: object) -> object:
+    """Convert enums to names so diagnostics stay JSON-friendly."""
+    if isinstance(value, Enum):
+        return value.name
+    return value
+
+
+def _platform_label(device: DeyeApiResponseDeviceInfo) -> str:
+    """Return Classic / Fog / FogCombo from the device-list platform id."""
+    platform = device["platform"]
+    if isinstance(platform, DeyeIotPlatform):
+        return platform.name
+    try:
+        return DeyeIotPlatform(platform).name
+    except ValueError:
+        return str(platform)
+
+
+def _device_metadata(device: DeyeApiResponseDeviceInfo) -> dict[str, Any]:
+    """Return non-secret device-list fields plus Classic/Fog labels."""
+    metadata = {
+        key: _serialize_value(device[key])
+        for key in _DEVICE_METADATA_KEYS
+        if key in device
+    }
+    metadata["platform"] = _platform_label(device)
+    metadata["transport"] = _enum_name(transport_for_device(device))
+    return metadata
+
+
+def _state_snapshot(state: DeyeDeviceState) -> dict[str, Any]:
+    """Return the current public device state without unused internals."""
+    return {
+        field: _serialize_value(getattr(state, field))
+        for field in _STATE_FIELDS
+        if hasattr(state, field)
+    }
+
+
+def _mqtt_connected(mqtt_client: object) -> bool | None:
+    """Return paho connected-ish flag when the MQTT wrapper exposes it."""
+    paho_client = getattr(mqtt_client, "_mqtt", None)
+    is_connected = getattr(paho_client, "is_connected", None)
+    if not callable(is_connected):
+        return None
+    return bool(is_connected())
+
+
+def _mqtt_clients_snapshot(client: object) -> list[dict[str, Any]]:
+    """Return connected-ish flags for pooled Classic/Fog MQTT clients."""
+    mqtt_by_type = getattr(client, "_mqtt_by_type", None)
+    if not isinstance(mqtt_by_type, dict):
+        return []
+    snapshots: list[dict[str, Any]] = []
+    for client_cls, mqtt_client in mqtt_by_type.items():
+        snapshots.append(
+            {
+                "type": getattr(client_cls, "__name__", type(mqtt_client).__name__),
+                "connected": _mqtt_connected(mqtt_client),
+                "host": getattr(mqtt_client, "_mqtt_host", None),
+                "port": getattr(mqtt_client, "_mqtt_ssl_port", None),
+            }
+        )
+    return snapshots
+
+
+def _coordinator_snapshot(
+    coordinator: DeyeDataUpdateCoordinator | None,
+) -> dict[str, Any]:
+    """Return availability and a non-secret state snapshot."""
+    if coordinator is None or coordinator.data is None:
+        return {
+            "available": None,
+            "last_update_success": None,
+            "mqtt_connected": None,
+            "state": None,
+        }
+    device_mqtt = getattr(coordinator, "device", None)
+    mqtt_client = getattr(device_mqtt, "_mqtt", None)
+    return {
+        "available": coordinator.data.available,
+        "last_update_success": coordinator.last_update_success,
+        "mqtt_connected": _mqtt_connected(mqtt_client) if mqtt_client else None,
+        "state": _state_snapshot(coordinator.data.state),
+    }
+
+
+def _device_diagnostics(
+    device: DeyeApiResponseDeviceInfo,
+    coordinator: DeyeDataUpdateCoordinator | None,
+) -> dict[str, Any]:
+    """Build diagnostics for one dehumidifier."""
+    coordinator_data = _coordinator_snapshot(coordinator)
+    metadata = _device_metadata(device)
+    return {
+        "product_id": metadata.get("product_id"),
+        "product_name": metadata.get("product_name"),
+        "platform": metadata.get("platform"),
+        "transport": metadata.get("transport"),
+        "online": metadata.get("online"),
+        "available": coordinator_data["available"],
+        "device": metadata,
+        "state": coordinator_data["state"],
+        "last_update_success": coordinator_data["last_update_success"],
+        "mqtt_connected": coordinator_data["mqtt_connected"],
+    }
+
+
+def _entry_runtime_data(hass: HomeAssistant, entry: ConfigEntry) -> ConfigEntryData:
+    """Read config-entry runtime data the same way as other platforms."""
+    return hass.data[DATA_KEY][entry.entry_id]
+
+
+def _match_device(
+    devices: list[DeyeApiResponseDeviceInfo], device_entry: DeviceEntry
+) -> DeyeApiResponseDeviceInfo | None:
+    """Find the device-list row for a Home Assistant device registry entry."""
+    macs = {
+        identifier[1]
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+    }
+    if device_entry.serial_number:
+        macs.add(device_entry.serial_number)
+    for device in devices:
+        if device["mac"] in macs:
+            return device
+    return None
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data = _entry_runtime_data(hass, entry)
+    return async_redact_data(
+        {
+            "entry": {
+                "title": entry.title,
+                "domain": entry.domain,
+                "entry_id": entry.entry_id,
+                "version": entry.version,
+                "data": dict(entry.data),
+                "options": dict(entry.options),
+            },
+            "mqtt_clients": _mqtt_clients_snapshot(data.client),
+            "devices": [
+                _device_diagnostics(
+                    device, data.coordinator_map.get(device["device_id"])
+                )
+                for device in data.device_list
+            ],
+        },
+        TO_REDACT,
+    )
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a single device."""
+    data = _entry_runtime_data(hass, entry)
+    matched = _match_device(data.device_list, device)
+    if matched is None:
+        return {"error": "Device is not part of this config entry"}
+    return async_redact_data(
+        _device_diagnostics(matched, data.coordinator_map.get(matched["device_id"])),
+        TO_REDACT,
+    )


### PR DESCRIPTION
## Summary

Adds the Home Assistant gold quality-scale [`diagnostics`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/diagnostics) platform.

`custom_components/deye_dehumidifier/diagnostics.py` is auto-discovered (not added to `PLATFORMS`) and implements:

- `async_get_config_entry_diagnostics`
- `async_get_device_diagnostics` (matched by `(domain, mac)` / serial)

Runtime data is read from `hass.data[DATA_KEY]` the same way as the other platforms, so this stands alone on current `main` without a `runtime_data` migration.

Each device snapshot includes:

- `product_id` / `product_name`
- `platform` (`Classic` / `Fog` / `FogCombo`) and official `transport`
- `online` (device-list) and `available` (coordinator)
- current non-secret state (switches, mode, fan, humidity/temperature)
- device-list metadata (ids, mac, protocol, combo, etc.; no payload/icons)
- MQTT connected-ish flags for pooled Classic/Fog clients when the paho wrapper is present

Secrets are stripped with `async_redact_data`:

- `password`, `auth_token`, `username` (account and MQTT)
- `loginname`, `token`
- any nested MQTT credential keys if they appear later

## Test plan

- [x] `uv run mypy .` — no issues in 12 source files
- [x] `uv run pylint custom_components/deye_dehumidifier/diagnostics.py`
- [x] `uv run ruff check` / `ruff format --check` and `pre-commit` on `diagnostics.py`
- [x] Runtime mock of Classic + Fog devices: username/password/`auth_token` become `**REDACTED**`; injected MQTT `loginname`/`password` never appear; platforms, availability, state snapshot, and MQTT `connected` flags are present; device diagnostics match by MAC; unknown device returns an error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostics with credential redaction; no changes to control paths, auth, or device communication.
> 
> **Overview**
> Adds a new **diagnostics** platform (`diagnostics.py`) so users and support can download integration debug data from Home Assistant without exposing credentials.
> 
> **Config entry diagnostics** include redacted entry metadata, a snapshot of pooled Classic/Fog MQTT clients (type, host, port, connected when available), and per-device blocks for every device on the account. **Device diagnostics** resolve the registry entry by domain MAC/serial, return the same per-device payload, or an error if the device is not on that entry.
> 
> Each device report surfaces cloud-list metadata (ids, MAC, product, platform as Classic/Fog/FogCombo, transport), online vs coordinator **available**, update success, per-device MQTT connectivity, and a JSON-friendly slice of live state (switches, mode, fan, humidity/temperature, etc.). Secrets are stripped via `async_redact_data` for username/password/auth token and common MQTT credential keys. Runtime data is read from `hass.data[DATA_KEY]` like the other platforms, so no `PLATFORMS` or manifest change is required for discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b85ee457be9f32b0c42bb4c6c9e967479952d24. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->