### PR TITLE
Stop setting entity_id; let Home Assistant generate it

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -142,7 +142,6 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
         self._device = device
         self._attr_has_entity_name = True
         self._attr_unique_id = self._device["mac"]
-        self.entity_id_base = f"deye_{self._device['mac'].lower()}"  # We will override HA generated entity ID
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device["mac"])},
             model=self._device["product_name"],

--- a/custom_components/deye_dehumidifier/binary_sensor.py
+++ b/custom_components/deye_dehumidifier/binary_sensor.py
@@ -61,7 +61,6 @@ class DeyeWaterTankBinarySensor(DeyeEntity, BinarySensorEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-water-tank"
-        self.entity_id = f"binary_sensor.{self.entity_id_base}_water_tank"
 
     @property
     @override
@@ -86,7 +85,6 @@ class DeyeDefrostingBinarySensor(DeyeEntity, BinarySensorEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-defrosting"
-        self.entity_id = f"binary_sensor.{self.entity_id_base}_defrosting"
 
     @property
     @override

--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -84,7 +84,6 @@ class DeyeFan(DeyeEntity, FanEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-fan"
-        self.entity_id = f"fan.{self.entity_id_base}_fan"
         feature_config = get_product_feature_config(device["product_id"])
         self._attr_supported_features = (
             FanEntityFeature.SET_SPEED

--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -66,7 +66,6 @@ class DeyeDehumidifier(DeyeEntity, HumidifierEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-dehumidifier"
-        self.entity_id = f"humidifier.{self.entity_id_base}_dehumidifier"
         feature_config = get_product_feature_config(device["product_id"])
         if len(feature_config["mode"]) > 0:
             self._attr_supported_features = HumidifierEntityFeature.MODES

--- a/custom_components/deye_dehumidifier/sensor.py
+++ b/custom_components/deye_dehumidifier/sensor.py
@@ -63,7 +63,6 @@ class DeyeHumiditySensor(DeyeEntity, SensorEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-humidity"
-        self.entity_id = f"sensor.{self.entity_id_base}_humidity"
 
     @property
     @override
@@ -89,7 +88,6 @@ class DeyeTemperatureSensor(DeyeEntity, SensorEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-temperature"
-        self.entity_id = f"sensor.{self.entity_id_base}_temperature"
 
     @property
     @override

--- a/custom_components/deye_dehumidifier/switch.py
+++ b/custom_components/deye_dehumidifier/switch.py
@@ -109,9 +109,6 @@ class DeyeConfigSwitch(DeyeEntity, SwitchEntity):
         assert self._attr_unique_id is not None
         self._attr_translation_key = spec.translation_key
         self._attr_unique_id += f"-{spec.unique_suffix}"
-        self.entity_id = (
-            f"switch.{self.entity_id_base}_{spec.unique_suffix.replace('-', '_')}"
-        )
         self._state_attr = spec.state_attr
 
     @property
@@ -150,7 +147,6 @@ class DeyeContinuousSwitch(DeyeEntity, SwitchEntity):
         super().__init__(coordinator, device)
         assert self._attr_unique_id is not None
         self._attr_unique_id += "-continuous"
-        self.entity_id = f"switch.{self.entity_id_base}_continuous"
         self._min_supported_humidity = min_supported_humidity
 
     @property


### PR DESCRIPTION
## Summary

Stop assigning `entity_id` on Deye entities. Home Assistant 2026.4 deprecates setting `entity_id` when the domain does not match; Home Assistant should generate it from `unique_id` plus `has_entity_name`.

- Remove every `self.entity_id = ...` assignment in `humidifier.py`, `sensor.py`, `switch.py`, `binary_sensor.py`, and `fan.py`.
- Remove unused `entity_id_base` from `DeyeEntity`.
- Keep the existing `unique_id` scheme and suffixes (`-dehumidifier`, `-humidity`, `-temperature`, `-child-lock`, `-anion`, `-water-pump`, `-uv`, `-prompt-sound`, `-screen-display`, `-continuous`, `-water-tank`, `-defrosting`, `-fan`) so entity registry identity stays stable.

`_attr_has_entity_name = True` is unchanged.

## Existing installs

**Existing installed `entity_id`s in users' entity registries will remain.** Home Assistant matches entities by `unique_id`, so already-registered devices keep their current ids (for example `humidifier.deye_{mac}_dehumidifier`). Only new installs (or newly created entities with no registry entry) get Home Assistant-generated ids from the device name and entity name.

## Test plan

- [x] AST check: no `self.entity_id` assignments and no `entity_id_base` remaining.
- [x] `unique_id` suffixes unchanged, including switch `_FlagSwitchSpec.unique_suffix` values.
- [x] `_attr_has_entity_name = True` still set on `DeyeEntity`.
- [x] `ruff check` / `ruff format --check` / `mypy` / `pylint` clean on the integration.
- [ ] After merge: existing installs keep previous `entity_id`s; a fresh install gets HA-generated ids.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical entity-ID plumbing only; stable `unique_id`s preserve existing automations and registry entries for upgraded installs.
> 
> **Overview**
> Aligns with **Home Assistant 2026.4**, which deprecates manually setting `entity_id` when it does not match the expected pattern. The integration no longer assigns `self.entity_id` on humidifier, sensor, switch, binary sensor, or fan entities, and drops the unused `entity_id_base` helper on `DeyeEntity`.
> 
> **Entity registry identity is unchanged:** `unique_id` suffixes (e.g. `-dehumidifier`, `-humidity`, switch spec suffixes) and `_attr_has_entity_name = True` stay as before. Existing installs keep their registered `entity_id`s via `unique_id` matching; only new entities without a registry entry get HA-generated ids from device and entity naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7883db55bb903dc59683080bd6c04dc76897f50c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->