### PR TITLE
feat: store config entry data on entry.runtime_data

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import ssl
-from homeassistant.util.hass_dict import HassKey
 
 from .const import CONF_AUTH_TOKEN, CONF_PASSWORD, CONF_USERNAME, DOMAIN, MANUFACTURER
 from .data_coordinator import DeyeDataUpdateCoordinator
@@ -39,8 +38,6 @@ PLATFORMS: list[Platform] = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
-
-DATA_KEY: HassKey[dict[str, ConfigEntryData]] = HassKey(DOMAIN)
 
 _DEHUMIDIFIER_PRODUCT_TYPES = {"dehumidifier", "除湿机", "其他"}
 
@@ -73,7 +70,10 @@ class ConfigEntryData:
     coordinator_map: dict[str, DeyeDataUpdateCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+type DeyeConfigEntry = ConfigEntry[ConfigEntryData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool:
     """Set up Deye Dehumidifier from a config entry."""
 
     def on_auth_token_refreshed(auth_token: str) -> None:
@@ -108,8 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except DeyeCloudApiCannotConnectError as err:
         raise ConfigEntryNotReady from err
 
-    hass.data.setdefault(DATA_KEY, {})
-    hass.data[DATA_KEY][entry.entry_id] = ConfigEntryData(
+    entry.runtime_data = ConfigEntryData(
         client=client,
         device_list=[device.info for device in devices],
         coordinator_map=coordinator_map,
@@ -120,13 +119,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data = hass.data[DATA_KEY].pop(entry.entry_id)
-        for coordinator in data.coordinator_map.values():
+        for coordinator in entry.runtime_data.coordinator_map.values():
             coordinator.unsubscribe()
-        data.client.disconnect()
+        entry.runtime_data.client.disconnect()
 
     return unload_ok
 

--- a/custom_components/deye_dehumidifier/binary_sensor.py
+++ b/custom_components/deye_dehumidifier/binary_sensor.py
@@ -8,12 +8,11 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_KEY, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -22,11 +21,11 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add sensors for passed config_entry in HA."""
-    data = hass.data[DATA_KEY][config_entry.entry_id]
+    """Add binary sensors for this config entry."""
+    data = entry.runtime_data
     async_add_entities(
         [
             sensor

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -12,7 +12,6 @@ from libdeye.cloud_api import (
 from libdeye.device_state import DeyeDeviceState
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from . import DATA_KEY, ConfigEntryData
+from . import ConfigEntryData, DeyeConfigEntry
 from .const import CONF_AUTH_TOKEN, CONF_PASSWORD, CONF_USERNAME, DOMAIN
 from .data_coordinator import DeyeDataUpdateCoordinator
 
@@ -189,9 +189,9 @@ def _device_diagnostics(
     }
 
 
-def _entry_runtime_data(hass: HomeAssistant, entry: ConfigEntry) -> ConfigEntryData:
-    """Read config-entry runtime data the same way as other platforms."""
-    return hass.data[DATA_KEY][entry.entry_id]
+def _entry_runtime_data(entry: DeyeConfigEntry) -> ConfigEntryData:
+    """Read config-entry runtime data from the typed entry."""
+    return entry.runtime_data
 
 
 def _match_device(
@@ -213,10 +213,10 @@ def _match_device(
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: DeyeConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data = _entry_runtime_data(hass, entry)
+    data = _entry_runtime_data(entry)
     return async_redact_data(
         {
             "entry": {
@@ -240,10 +240,10 @@ async def async_get_config_entry_diagnostics(
 
 
 async def async_get_device_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
+    hass: HomeAssistant, entry: DeyeConfigEntry, device: DeviceEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a single device."""
-    data = _entry_runtime_data(hass, entry)
+    data = _entry_runtime_data(entry)
     matched = _match_device(data.device_list, device)
     if matched is None:
         return {"error": "Device is not part of this config entry"}

--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -6,7 +6,6 @@ from libdeye.cloud_api import DeyeApiResponseDeviceInfo
 from libdeye.const import DeyeFanSpeed, get_product_feature_config
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
@@ -14,7 +13,7 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from . import DATA_KEY, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -53,11 +52,11 @@ def preset_mode_to_deye_fan_speed(preset_mode: str) -> DeyeFanSpeed:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add fans for passed config_entry in HA."""
-    data = hass.data[DATA_KEY][config_entry.entry_id]
+    """Add fans for this config entry."""
+    data = entry.runtime_data
     async_add_entities(
         [
             DeyeFan(

--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -14,11 +14,10 @@ from homeassistant.components.humidifier import (
     HumidifierEntity,
     HumidifierEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_KEY, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 MODE_AIR_PURIFIER = "air_purifier"
@@ -34,11 +33,11 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add dehumidifiers for passed config_entry in HA."""
-    data = hass.data[DATA_KEY][config_entry.entry_id]
+    """Add dehumidifiers for this config entry."""
+    data = entry.runtime_data
     async_add_entities(
         [
             DeyeDehumidifier(

--- a/custom_components/deye_dehumidifier/sensor.py
+++ b/custom_components/deye_dehumidifier/sensor.py
@@ -9,12 +9,11 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfRatio, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_KEY, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -23,11 +22,11 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add sensors for passed config_entry in HA."""
-    data = hass.data[DATA_KEY][config_entry.entry_id]
+    """Add sensors for this config entry."""
+    data = entry.runtime_data
     async_add_entities(
         [
             sensor

--- a/custom_components/deye_dehumidifier/switch.py
+++ b/custom_components/deye_dehumidifier/switch.py
@@ -6,12 +6,11 @@ from libdeye.cloud_api import DeyeApiResponseDeviceInfo
 from libdeye.const import DeyeDeviceMode, DeyeProductConfig, get_product_feature_config
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_KEY, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 
@@ -59,11 +58,11 @@ def _feature_flag_enabled(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add switches for passed config_entry in HA."""
-    data = hass.data[DATA_KEY][config_entry.entry_id]
+    """Add switches for this config entry."""
+    data = entry.runtime_data
 
     entities: list[SwitchEntity] = []
     for device in data.device_list:


### PR DESCRIPTION
## Summary

Migrate integration runtime state from `hass.data` / `HassKey` to typed `ConfigEntry.runtime_data`, matching the Home Assistant [bronze quality-scale `runtime-data`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data/) rule (HA 2024.4+).

- Add `type DeyeConfigEntry = ConfigEntry[ConfigEntryData]`
- `async_setup_entry` stores `ConfigEntryData` on `entry.runtime_data` instead of `hass.data[DATA_KEY][entry.entry_id]`
- Platforms (`humidifier`, `sensor`, `switch`, `binary_sensor`, `fan`) take `DeyeConfigEntry` and read `entry.runtime_data`
- Unload no longer pops `hass.data`; it still disconnects the Deye client via `entry.runtime_data.client.disconnect()`
- Remove unused `DATA_KEY` / `HassKey`

Entity behavior, coordinators, and platform setup loops are unchanged.

## Test plan

- [x] Grep: no remaining `DATA_KEY`, `HassKey`, or `hass.data` lookups in the integration
- [x] `python3 -m compileall custom_components/deye_dehumidifier`
- [x] `ruff check` / `ruff format --check` on the six touched files
- [ ] After merge: reload a config entry in Home Assistant and confirm platforms still set up and unload disconnects the client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only storage and typing change with no changes to device control or coordinator logic; unload still disconnects the client.
> 
> **Overview**
> Moves per-entry runtime state off `hass.data` / `HassKey` onto **typed** `entry.runtime_data`, aligning with Home Assistant’s runtime-data quality-scale pattern (HA 2024.4+).
> 
> Setup assigns a `ConfigEntryData` instance (client, device list, coordinator map) to `entry.runtime_data` and introduces `DeyeConfigEntry = ConfigEntry[ConfigEntryData]` for typed entry handling in `async_setup_entry` / `async_unload_entry`. Unload still disconnects the Deye client, now via `entry.runtime_data.client` instead of popping from `hass.data`. All platform modules (`humidifier`, `sensor`, `switch`, `binary_sensor`, `fan`) take `DeyeConfigEntry` and read `entry.runtime_data` instead of `hass.data[DATA_KEY][entry_id]`.
> 
> Entity behavior, coordinators, and platform entity loops are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff1bdeea662c13443f4820f713dacfc5570926c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->