### PR TITLE
chore: drop redundant Entity mixin from DeyeEntity

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import ssl
 from homeassistant.util.hass_dict import HassKey
@@ -107,7 +106,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator], Entity):
+class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
     """Initiate Deye Base Class."""
 
     def __init__(


### PR DESCRIPTION
## Summary

Drop the redundant `Entity` mixin from `DeyeEntity`.

`CoordinatorEntity` already extends Home Assistant's `Entity`, so `class DeyeEntity(CoordinatorEntity[...], Entity)` only duplicated the base. The extra mixin and `from homeassistant.helpers.entity import Entity` import are removed.

Out of scope (separate PRs):
- `entity_id` / `entity_id_base` is unchanged
- `async_add_entities` batching is unchanged

GitHub Actions: `actions/checkout` is already `@v7` on `main` (past `@v5`). `actions/setup-python` is unused (Python comes from `astral-sh/setup-uv`). No workflow churn in this PR.

## Test plan

- [x] `DeyeEntity` bases are only `CoordinatorEntity`; `Entity` is not imported
- [x] `entity_id_base` remains; no `async_add_entities` changes
- [x] `python3.14 -m compileall` on `custom_components/deye_dehumidifier`
- [x] `uv run ruff check` / `ruff format --check` on `__init__.py`
- [x] Installed Home Assistant: `CoordinatorEntity` MRO includes `Entity`; `issubclass(CoordinatorEntity, Entity)` is true
- [x] `uv run mypy custom_components/deye_dehumidifier/__init__.py` — no issues
- [ ] CI (hassfest, HACS, lint/type-check) on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class inheritance cleanup with no logic or API changes; entity behavior still comes from CoordinatorEntity’s Entity base.
> 
> **Overview**
> **`DeyeEntity`** no longer lists **`Entity`** as a second base class; it inherits only from **`CoordinatorEntity[DeyeDataUpdateCoordinator]`**, and the unused **`Entity`** import is removed.
> 
> Behavior is unchanged because **`CoordinatorEntity`** already subclasses **`Entity`**, so the extra mixin was redundant. Platform entities that extend **`DeyeEntity`** are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06af0c621aa131d3dd18292d596f5c89e8788fc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->