### PR TITLE
Modernize data coordinator updates, MQTT unsubscribe, and availability logging

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -124,6 +124,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data = hass.data[DATA_KEY].pop(entry.entry_id)
+        for coordinator in data.coordinator_map.values():
+            coordinator.unsubscribe()
         data.client.disconnect()
 
     return unload_ok

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -40,7 +40,7 @@ def _retry_after_from_exception(err: BaseException) -> float | None:
             if retry_after is not None:
                 try:
                     return max(float(retry_after), 0.0)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     pass
             return _DEFAULT_RATE_LIMIT_RETRY_AFTER
         current = current.__cause__ or current.__context__

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -5,14 +5,46 @@ import logging
 from typing import NamedTuple, override
 
 from libdeye.client import DeyeDevice
+from libdeye.cloud_api import (
+    DeyeCloudApiCannotConnectError,
+    DeyeCloudApiInvalidAuthError,
+)
 from libdeye.device_state import DeyeDeviceState
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
+
+_HTTP_TOO_MANY_REQUESTS = 429
+_DEFAULT_RATE_LIMIT_RETRY_AFTER = 60.0
+
+
+def _retry_after_from_exception(err: BaseException) -> float | None:
+    """Return a backoff in seconds when a rate-limit (HTTP 429) is detected."""
+    seen: set[int] = set()
+    current: BaseException | None = err
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        status = getattr(current, "status", None)
+        if status is None:
+            status = getattr(current, "status_code", None)
+        if status == _HTTP_TOO_MANY_REQUESTS:
+            headers = getattr(current, "headers", None)
+            retry_after = None
+            if headers is not None:
+                retry_after = headers.get("Retry-After") or headers.get("retry-after")
+            if retry_after is not None:
+                try:
+                    return max(float(retry_after), 0.0)
+                except TypeError, ValueError:
+                    pass
+            return _DEFAULT_RATE_LIMIT_RETRY_AFTER
+        current = current.__cause__ or current.__context__
+    return None
 
 
 class DeyeDeviceData(NamedTuple):
@@ -38,27 +70,49 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
             _LOGGER,
             config_entry=config_entry,
             name=f"{device.name} ({device.device_id})",
-            update_method=self.poll_device_state,
             update_interval=timedelta(seconds=30),
             always_update=False,
         )
         self.device = device
         self.state_update_muted: CALLBACK_TYPE | None = None
+        self._unsubscribers: list[CALLBACK_TYPE] = []
+        self._unavailable_logged = False
 
     @override
     async def _async_setup(self) -> None:
-        """Set up the coordinator."""
+        """Set up the coordinator and subscribe to MQTT state changes."""
         await self.device.ensure_connected()
         reported_state = self.device.reported_state
+        available = self.device.available
         self.data = DeyeDeviceData(
             reported_state=reported_state,
             state=reported_state.copy(),
-            available=self.device.available,
+            available=available,
         )
-        self.device.subscribe(
-            on_state=self.update_device_state,
-            on_availability=self.update_device_availability,
+        self._log_availability(available)
+        self._unsubscribers.append(
+            self.device.subscribe(
+                on_state=self.update_device_state,
+                on_availability=self.update_device_availability,
+            )
         )
+        if self.config_entry is not None:
+            self.config_entry.async_on_unload(self.unsubscribe)
+
+    @callback
+    def unsubscribe(self) -> None:
+        """Remove MQTT subscriptions so callbacks do not leak after unload."""
+        while self._unsubscribers:
+            self._unsubscribers.pop()()
+        if self.state_update_muted:
+            self.state_update_muted()
+            self.state_update_muted = None
+
+    @override
+    async def async_shutdown(self) -> None:
+        """Unsubscribe MQTT callbacks and shut down the coordinator."""
+        self.unsubscribe()
+        await super().async_shutdown()
 
     def mute_state_update_for_a_while(self) -> None:
         """Mute subscription for a while to avoid state bouncing."""
@@ -85,6 +139,7 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
 
     def update_device_availability(self, available: bool) -> None:
         """Will be called when received device availability change."""
+        self._log_availability(available)
         self.async_set_updated_data(
             DeyeDeviceData(
                 reported_state=self.data.reported_state,
@@ -92,6 +147,17 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
                 available=available,
             )
         )
+
+    def _log_availability(self, available: bool) -> None:
+        """Log once when a device becomes unavailable, and once when it recovers."""
+        if available:
+            if self._unavailable_logged:
+                _LOGGER.info("%s is available again", self.name)
+                self._unavailable_logged = False
+            return
+        if not self._unavailable_logged:
+            _LOGGER.info("%s is unavailable", self.name)
+            self._unavailable_logged = True
 
     def sync_reported_state_after_publish(self) -> None:
         """Align reported state with the desired state after a successful publish."""
@@ -101,12 +167,27 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
             available=self.data.available,
         )
 
-    async def poll_device_state(self) -> DeyeDeviceData:
-        """Some Deye devices have a very long heartbeat period. So polling is still necessary."""
+    @override
+    async def _async_update_data(self) -> DeyeDeviceData:
+        """Poll device state. Some Deye devices have a long heartbeat period.
+
+        Fog uses HTTP ``RealData`` poll; Classic/Combo publish the MQTT query
+        command. Both keep mute-window behavior and wait for MQTT for the
+        next payload when ``request_refresh`` returns ``None``.
+        """
         if self.state_update_muted:
             return self.data
 
-        reported_state = await self.device.request_refresh()
+        try:
+            reported_state = await self.device.request_refresh()
+        except DeyeCloudApiInvalidAuthError as err:
+            raise ConfigEntryAuthFailed from err
+        except (DeyeCloudApiCannotConnectError, OSError) as err:
+            raise UpdateFailed(
+                f"Error communicating with {self.name}: {err}",
+                retry_after=_retry_after_from_exception(err),
+            ) from err
+
         if reported_state is None:
             return self.data
         return DeyeDeviceData(

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -40,7 +40,7 @@ def _retry_after_from_exception(err: BaseException) -> float | None:
             if retry_after is not None:
                 try:
                     return max(float(retry_after), 0.0)
-                except (TypeError, ValueError):
+                except TypeError, ValueError:
                     pass
             return _DEFAULT_RATE_LIMIT_RETRY_AFTER
         current = current.__cause__ or current.__context__


### PR DESCRIPTION
## Summary

Home Assistant quality scale: **[log-when-unavailable](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/log-when-unavailable/)** plus current coordinator patterns.

`DeyeDataUpdateCoordinator` now follows the current Home Assistant coordinator API and cleans up MQTT callbacks on unload:

1. **`_async_update_data`** replaces `update_method=self.poll_device_state`. Interval stays 30s, `always_update=False`, `config_entry=` is unchanged.
2. **Poll / MQTT / API failures** raise `UpdateFailed`. `DeyeCloudApiInvalidAuthError` is re-raised as `ConfigEntryAuthFailed` so first refresh can start reauth. If an HTTP 429 (and optional `Retry-After`) is visible in the exception chain, `UpdateFailed(retry_after=...)` is used; otherwise a plain `UpdateFailed`.
3. **MQTT unsubscribe:** `DeyeDevice.subscribe()` returns an unsubscribe callable (wrapping libdeye `subscribe_state_change` / `subscribe_availability_change`). It is stored in `_async_setup`, registered with `config_entry.async_on_unload`, invoked from `async_shutdown`, and called from `async_unload_entry` **before** `client.disconnect()` so callbacks do not leak.
4. **`log-when-unavailable`:** log once at info when a device becomes unavailable, and once when it recovers. Coordinator `UpdateFailed` uses Home Assistant's built-in first-failure / recovery logging so poll errors are not logged every 30s.

`mute_state_update_for_a_while` and Fog vs Classic/Combo poll behavior (`device.request_refresh()`) are unchanged. This PR does **not** migrate `runtime_data` or add subentries.

## Test plan

- [x] `ruff check` / `ruff format --check` on `data_coordinator.py` and `__init__.py`
- [x] `python3.14 -m compileall` on `custom_components/deye_dehumidifier`
- [x] Behavioral checks (38/38): `_async_update_data` vs `update_method`; `UpdateFailed` / `ConfigEntryAuthFailed` / `retry_after`; unsubscribe on shutdown and entry unload; availability log-once / recover-once; mute + Fog/Classic poll unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator refresh, auth failure handling, and MQTT lifecycle on unload; behavior is localized but affects how devices stay in sync and how errors propagate during polling.
> 
> **Overview**
> **`DeyeDataUpdateCoordinator`** is aligned with current Home Assistant patterns: polling moves from `update_method=poll_device_state` to **`_async_update_data`** (30s interval and mute behavior unchanged).
> 
> Poll/API failures now surface as **`UpdateFailed`** (with optional **`retry_after`** when HTTP 429 appears in the exception chain) or **`ConfigEntryAuthFailed`** for invalid cloud auth. MQTT **`subscribe`** return values are tracked and torn down via **`unsubscribe`**, **`async_shutdown`**, **`config_entry.async_on_unload`**, and **`async_unload_entry`** before **`client.disconnect()`** to avoid leaking callbacks.
> 
> Adds **log-when-unavailable** quality-scale behavior: one info log when a device goes unavailable and one when it recovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4964c278a2b1aa9f67817c56666ccd2899552f49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->