### PR TITLE
feat: discover new devices and remove stale ones

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -1,9 +1,9 @@
 """The Deye Dehumidifier integration."""
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 import logging
-from typing import override
+from typing import TypeVar, override
 
 from libdeye.client import DeyeClient
 from libdeye.cloud_api import (
@@ -25,8 +25,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import ssl
 
@@ -173,12 +171,15 @@ async def async_remove_config_entry_device(
     return not is_known_dehumidifier_identifier(device_entry.identifiers, current_macs)
 
 
+_T = TypeVar("_T")
+
+
 def async_setup_dynamic_entities(
     hass: HomeAssistant,
     config_entry: DeyeConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: Callable[[Iterable[_T]], object],
     entity_factory: Callable[
-        [DeyeDataUpdateCoordinator, DeyeApiResponseDeviceInfo], Sequence[Entity]
+        [DeyeDataUpdateCoordinator, DeyeApiResponseDeviceInfo], Sequence[_T]
     ],
 ) -> None:
     """Add entities now and whenever a new dehumidifier is discovered."""
@@ -189,7 +190,7 @@ def async_setup_dynamic_entities(
     def _async_add_new_devices() -> None:
         current_ids = {device["device_id"] for device in data.device_list}
         known_devices.intersection_update(current_ids)
-        new_entities: list[Entity] = []
+        new_entities: list[_T] = []
         for device in data.device_list:
             device_id = device["device_id"]
             if device_id in known_devices:

--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -1,5 +1,6 @@
 """The Deye Dehumidifier integration."""
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 import logging
 from typing import override
@@ -14,20 +15,30 @@ from libdeye.cloud_api import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryNotReady,
     HomeAssistantError,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import ssl
 
-from .const import CONF_AUTH_TOKEN, CONF_PASSWORD, CONF_USERNAME, DOMAIN, MANUFACTURER
-from .data_coordinator import DeyeDataUpdateCoordinator
+from .const import (
+    CONF_AUTH_TOKEN,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DOMAIN,
+    MANUFACTURER,
+    is_known_dehumidifier_identifier,
+)
+from .data_coordinator import DeyeDataUpdateCoordinator, DeyeDeviceListCoordinator
 from .issues import (
     MqttDisconnectMonitor,
     async_delete_entry_issues,
@@ -43,8 +54,6 @@ PLATFORMS: list[Platform] = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
-
-_DEHUMIDIFIER_PRODUCT_TYPES = {"dehumidifier", "除湿机", "其他"}
 
 
 def _wrap_command_exception(err: Exception) -> HomeAssistantError:
@@ -73,6 +82,7 @@ class ConfigEntryData:
     client: DeyeClient
     device_list: list[DeyeApiResponseDeviceInfo]
     coordinator_map: dict[str, DeyeDataUpdateCoordinator]
+    device_list_coordinator: DeyeDeviceListCoordinator
     mqtt_monitor: MqttDisconnectMonitor | None = None
 
 
@@ -87,44 +97,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool
             entry, data=entry.data | {CONF_AUTH_TOKEN: auth_token}
         )
 
+    cloud_api = DeyeCloudApi(
+        async_get_clientsession(hass),
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        entry.data[CONF_AUTH_TOKEN],
+    )
+    cloud_api.on_auth_token_refreshed = on_auth_token_refreshed
+    client = DeyeClient(cloud_api, ssl.get_default_context())
+    coordinator_map: dict[str, DeyeDataUpdateCoordinator] = {}
+    device_list: list[DeyeApiResponseDeviceInfo] = []
+    device_list_coordinator = DeyeDeviceListCoordinator(
+        hass, entry, client, coordinator_map, device_list
+    )
+
     try:
-        cloud_api = DeyeCloudApi(
-            async_get_clientsession(hass),
-            entry.data[CONF_USERNAME],
-            entry.data[CONF_PASSWORD],
-            entry.data[CONF_AUTH_TOKEN],
-        )
-        cloud_api.on_auth_token_refreshed = on_auth_token_refreshed
-        client = DeyeClient(cloud_api, ssl.get_default_context())
+        await device_list_coordinator.async_config_entry_first_refresh()
+    except ConfigEntryAuthFailed, ConfigEntryNotReady:
+        await device_list_coordinator.async_shutdown()
+        for coordinator in list(coordinator_map.values()):
+            await coordinator.async_shutdown()
+        client.disconnect()
+        raise
 
-        devices = [
-            device
-            for device in await client.list_devices()
-            if device.info["product_type"] in _DEHUMIDIFIER_PRODUCT_TYPES
-        ]
-
-        coordinator_map: dict[str, DeyeDataUpdateCoordinator] = {}
-        for device in devices:
-            coordinator = DeyeDataUpdateCoordinator(hass, entry, device)
-            await coordinator.async_config_entry_first_refresh()
-            coordinator_map[device.device_id] = coordinator
-
-    except DeyeCloudApiInvalidAuthError as err:
-        raise ConfigEntryAuthFailed from err
-    except DeyeCloudApiCannotConnectError as err:
-        raise ConfigEntryNotReady from err
-
-    device_infos = [device.info for device in devices]
     mqtt_monitor = MqttDisconnectMonitor(hass, entry.entry_id, client)
     entry.runtime_data = ConfigEntryData(
         client=client,
-        device_list=device_infos,
+        device_list=device_list,
         coordinator_map=coordinator_map,
+        device_list_coordinator=device_list_coordinator,
         mqtt_monitor=mqtt_monitor,
     )
 
-    async_sync_unknown_product_issues(hass, entry.entry_id, device_infos)
+    async_sync_unknown_product_issues(hass, entry.entry_id, device_list)
     mqtt_monitor.async_start()
+
+    @callback
+    def _async_sync_issues() -> None:
+        async_sync_unknown_product_issues(
+            hass, entry.entry_id, entry.runtime_data.device_list
+        )
+
+    entry.async_on_unload(
+        device_list_coordinator.async_add_listener(_async_sync_issues)
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -138,11 +154,58 @@ async def async_unload_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> boo
         if data.mqtt_monitor is not None:
             data.mqtt_monitor.async_stop()
         async_delete_entry_issues(hass, entry.entry_id)
+        await data.device_list_coordinator.async_shutdown()
         for coordinator in data.coordinator_map.values():
-            coordinator.unsubscribe()
+            await coordinator.async_shutdown()
         data.client.disconnect()
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: DeyeConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow deleting a device that is no longer on the Deye account."""
+    data = getattr(entry, "runtime_data", None)
+    if data is None:
+        return True
+    current_macs = {device["mac"] for device in data.device_list}
+    return not is_known_dehumidifier_identifier(device_entry.identifiers, current_macs)
+
+
+def async_setup_dynamic_entities(
+    hass: HomeAssistant,
+    config_entry: DeyeConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_factory: Callable[
+        [DeyeDataUpdateCoordinator, DeyeApiResponseDeviceInfo], Sequence[Entity]
+    ],
+) -> None:
+    """Add entities now and whenever a new dehumidifier is discovered."""
+    data = config_entry.runtime_data
+    known_devices: set[str] = set()
+
+    @callback
+    def _async_add_new_devices() -> None:
+        current_ids = {device["device_id"] for device in data.device_list}
+        known_devices.intersection_update(current_ids)
+        new_entities: list[Entity] = []
+        for device in data.device_list:
+            device_id = device["device_id"]
+            if device_id in known_devices:
+                continue
+            coordinator = data.coordinator_map.get(device_id)
+            if coordinator is None:
+                continue
+            known_devices.add(device_id)
+            new_entities.extend(entity_factory(coordinator, device))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _async_add_new_devices()
+    config_entry.async_on_unload(
+        data.device_list_coordinator.async_add_listener(_async_add_new_devices)
+    )
 
 
 def deye_device_configuration_url(

--- a/custom_components/deye_dehumidifier/binary_sensor.py
+++ b/custom_components/deye_dehumidifier/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DeyeConfigEntry, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity, async_setup_dynamic_entities
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -25,22 +25,14 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add binary sensors for this config entry."""
-    data = entry.runtime_data
-    async_add_entities(
-        [
-            sensor
-            for device in data.device_list
-            for sensor in (
-                DeyeWaterTankBinarySensor(
-                    data.coordinator_map[device["device_id"]],
-                    device,
-                ),
-                DeyeDefrostingBinarySensor(
-                    data.coordinator_map[device["device_id"]],
-                    device,
-                ),
-            )
-        ]
+    async_setup_dynamic_entities(
+        hass,
+        entry,
+        async_add_entities,
+        lambda coordinator, device: [
+            DeyeWaterTankBinarySensor(coordinator, device),
+            DeyeDefrostingBinarySensor(coordinator, device),
+        ],
     )
 
 

--- a/custom_components/deye_dehumidifier/const.py
+++ b/custom_components/deye_dehumidifier/const.py
@@ -15,3 +15,24 @@ ISSUE_TRACKER_URL = "https://github.com/stackia/ha-deye-dehumidifier/issues"
 # Ignore brief MQTT reconnects; only raise a repair after this long.
 MQTT_DISCONNECT_ISSUE_DELAY = timedelta(minutes=15)
 MQTT_DISCONNECT_CHECK_INTERVAL = timedelta(minutes=1)
+
+# The product_type was initially set to "dehumidifier"
+# but at some point (around 06/18/2025) it was changed to "除湿机" or "其他"
+DEHUMIDIFIER_PRODUCT_TYPES = frozenset({"dehumidifier", "除湿机", "其他"})
+
+DEVICE_LIST_UPDATE_INTERVAL = timedelta(minutes=5)
+
+
+def is_dehumidifier_product_type(product_type: str) -> bool:
+    """Return True if the cloud product_type is a dehumidifier we support."""
+    return product_type in DEHUMIDIFIER_PRODUCT_TYPES
+
+
+def is_known_dehumidifier_identifier(
+    identifiers: set[tuple[str, str]], current_macs: set[str]
+) -> bool:
+    """Return True if a device-registry identifier is still on the account."""
+    return any(
+        domain == DOMAIN and identifier in current_macs
+        for domain, identifier in identifiers
+    )

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -4,8 +4,9 @@ from datetime import datetime, timedelta
 import logging
 from typing import NamedTuple, override
 
-from libdeye.client import DeyeDevice
+from libdeye.client import DeyeClient, DeyeDevice
 from libdeye.cloud_api import (
+    DeyeApiResponseDeviceInfo,
     DeyeCloudApiCannotConnectError,
     DeyeCloudApiInvalidAuthError,
 )
@@ -13,9 +14,12 @@ from libdeye.device_state import DeyeDeviceState
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEVICE_LIST_UPDATE_INTERVAL, DOMAIN, is_dehumidifier_product_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,3 +199,121 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
             state=reported_state.copy(),
             available=self.data.available,
         )
+
+
+class DeyeDeviceListCoordinator(DataUpdateCoordinator[list[DeyeApiResponseDeviceInfo]]):
+    """Periodically refresh the cloud device list and sync local devices."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        client: DeyeClient,
+        coordinator_map: dict[str, DeyeDataUpdateCoordinator],
+        device_list: list[DeyeApiResponseDeviceInfo],
+    ) -> None:
+        """Initialize the device-list coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} device list",
+            update_interval=DEVICE_LIST_UPDATE_INTERVAL,
+        )
+        self._client = client
+        self.coordinator_map = coordinator_map
+        self.device_list = device_list
+        self._initial_sync = True
+
+    @override
+    async def _async_update_data(self) -> list[DeyeApiResponseDeviceInfo]:
+        """Fetch the cloud device list and add or remove local devices."""
+        try:
+            devices = [
+                device
+                for device in await self._client.list_devices()
+                if is_dehumidifier_product_type(device.info["product_type"])
+            ]
+        except DeyeCloudApiInvalidAuthError as err:
+            raise ConfigEntryAuthFailed from err
+        except DeyeCloudApiCannotConnectError as err:
+            raise UpdateFailed("Cannot connect to Deye Cloud") from err
+
+        try:
+            await self._async_sync_devices(devices)
+        finally:
+            self._initial_sync = False
+
+        return list(self.device_list)
+
+    async def _async_sync_devices(self, devices: list[DeyeDevice]) -> None:
+        """Create coordinators for new devices and drop stale ones."""
+        current_ids = {device.device_id for device in devices}
+        previous_ids = set(self.coordinator_map)
+
+        for device_id in previous_ids - current_ids:
+            await self._async_remove_stale_device(device_id)
+
+        for device in devices:
+            if device.device_id not in self.coordinator_map:
+                await self._async_add_device(device)
+
+        self.device_list.clear()
+        self.device_list.extend(
+            device.info
+            for device in devices
+            if device.device_id in self.coordinator_map
+        )
+
+    async def _async_add_device(self, device: DeyeDevice) -> None:
+        """Create a coordinator for a newly discovered dehumidifier."""
+        if self.config_entry is None:
+            raise UpdateFailed("Config entry is missing")
+        coordinator = DeyeDataUpdateCoordinator(self.hass, self.config_entry, device)
+        try:
+            await coordinator.async_config_entry_first_refresh()
+        except ConfigEntryAuthFailed:
+            await coordinator.async_shutdown()
+            raise
+        except ConfigEntryNotReady:
+            await coordinator.async_shutdown()
+            if self._initial_sync:
+                raise
+            _LOGGER.exception(
+                "Failed to set up newly discovered dehumidifier %s (%s)",
+                device.name,
+                device.device_id,
+            )
+            return
+        self.coordinator_map[device.device_id] = coordinator
+        if not self._initial_sync:
+            _LOGGER.info(
+                "Discovered dehumidifier %s (%s)", device.name, device.device_id
+            )
+
+    async def _async_remove_stale_device(self, device_id: str) -> None:
+        """Remove a dehumidifier that is no longer on the Deye account."""
+        coordinator = self.coordinator_map.pop(device_id, None)
+        mac: str | None = None
+        if coordinator is not None:
+            mac = coordinator.device.info["mac"]
+            await coordinator.async_shutdown()
+        else:
+            for info in self.device_list:
+                if info["device_id"] == device_id:
+                    mac = info["mac"]
+                    break
+        if mac is None or self.config_entry is None:
+            return
+
+        device_registry = dr.async_get(self.hass)
+        get_by_identifier = getattr(
+            device_registry, "async_get_device_by_identifier", None
+        )
+        if callable(get_by_identifier):
+            device_entry = get_by_identifier((DOMAIN, mac), self.config_entry.entry_id)
+        else:
+            device_entry = device_registry.async_get_device(identifiers={(DOMAIN, mac)})
+        if device_entry is not None:
+            device_registry.async_remove_device(device_entry.id)
+            _LOGGER.info("Removed stale dehumidifier %s (%s)", mac, device_id)

--- a/custom_components/deye_dehumidifier/fan.py
+++ b/custom_components/deye_dehumidifier/fan.py
@@ -13,7 +13,7 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from . import DeyeConfigEntry, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity, async_setup_dynamic_entities
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -50,23 +50,22 @@ def preset_mode_to_deye_fan_speed(preset_mode: str) -> DeyeFanSpeed:
     return _PRESET_TO_DEYE_FAN_SPEED[preset_mode]
 
 
+def _fan_entities(
+    coordinator: DeyeDataUpdateCoordinator, device: DeyeApiResponseDeviceInfo
+) -> list[DeyeFan]:
+    """Return the fan entity when the product supports fan speeds."""
+    if not get_product_feature_config(device["product_id"])["fan_speed"]:
+        return []
+    return [DeyeFan(coordinator, device)]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add fans for this config entry."""
-    data = entry.runtime_data
-    async_add_entities(
-        [
-            DeyeFan(
-                data.coordinator_map[device["device_id"]],
-                device,
-            )
-            for device in data.device_list
-            if len(get_product_feature_config(device["product_id"])["fan_speed"]) > 0
-        ]
-    )
+    async_setup_dynamic_entities(hass, entry, async_add_entities, _fan_entities)
 
 
 class DeyeFan(DeyeEntity, FanEntity):

--- a/custom_components/deye_dehumidifier/humidifier.py
+++ b/custom_components/deye_dehumidifier/humidifier.py
@@ -17,7 +17,7 @@ from homeassistant.components.humidifier import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DeyeConfigEntry, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity, async_setup_dynamic_entities
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 MODE_AIR_PURIFIER = "air_purifier"
@@ -37,15 +37,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add dehumidifiers for this config entry."""
-    data = entry.runtime_data
-    async_add_entities(
-        [
-            DeyeDehumidifier(
-                data.coordinator_map[device["device_id"]],
-                device,
-            )
-            for device in data.device_list
-        ]
+    async_setup_dynamic_entities(
+        hass,
+        entry,
+        async_add_entities,
+        lambda coordinator, device: [DeyeDehumidifier(coordinator, device)],
     )
 
 

--- a/custom_components/deye_dehumidifier/sensor.py
+++ b/custom_components/deye_dehumidifier/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import UnitOfRatio, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DeyeConfigEntry, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity, async_setup_dynamic_entities
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 # Coordinator is used to centralize the data updates
@@ -26,22 +26,14 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add sensors for this config entry."""
-    data = entry.runtime_data
-    async_add_entities(
-        [
-            sensor
-            for device in data.device_list
-            for sensor in (
-                DeyeHumiditySensor(
-                    data.coordinator_map[device["device_id"]],
-                    device,
-                ),
-                DeyeTemperatureSensor(
-                    data.coordinator_map[device["device_id"]],
-                    device,
-                ),
-            )
-        ]
+    async_setup_dynamic_entities(
+        hass,
+        entry,
+        async_add_entities,
+        lambda coordinator, device: [
+            DeyeHumiditySensor(coordinator, device),
+            DeyeTemperatureSensor(coordinator, device),
+        ],
     )
 
 

--- a/custom_components/deye_dehumidifier/switch.py
+++ b/custom_components/deye_dehumidifier/switch.py
@@ -10,7 +10,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DeyeConfigEntry, DeyeEntity
+from . import DeyeConfigEntry, DeyeEntity, async_setup_dynamic_entities
 from .data_coordinator import DeyeDataUpdateCoordinator
 
 
@@ -56,35 +56,36 @@ def _feature_flag_enabled(
     return bool(feature_config[spec.feature_key])
 
 
+def _switch_entities(
+    coordinator: DeyeDataUpdateCoordinator, device: DeyeApiResponseDeviceInfo
+) -> list[SwitchEntity]:
+    """Return the switch entities advertised by this product."""
+    feature_config = get_product_feature_config(device["product_id"])
+    entities: list[SwitchEntity] = [
+        DeyeConfigSwitch(coordinator, device, spec) for spec in _ALWAYS_ON_FLAG_SWITCHES
+    ]
+    entities.append(
+        DeyeContinuousSwitch(
+            coordinator,
+            device,
+            feature_config["min_target_humidity"],
+        )
+    )
+    entities.extend(
+        DeyeConfigSwitch(coordinator, device, spec)
+        for spec in _FEATURE_FLAG_SWITCHES
+        if _feature_flag_enabled(feature_config, spec)
+    )
+    return entities
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: DeyeConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add switches for this config entry."""
-    data = entry.runtime_data
-
-    entities: list[SwitchEntity] = []
-    for device in data.device_list:
-        feature_config = get_product_feature_config(device["product_id"])
-        coordinator = data.coordinator_map[device["device_id"]]
-        entities.extend(
-            DeyeConfigSwitch(coordinator, device, spec)
-            for spec in _ALWAYS_ON_FLAG_SWITCHES
-        )
-        entities.append(
-            DeyeContinuousSwitch(
-                coordinator,
-                device,
-                feature_config["min_target_humidity"],
-            )
-        )
-        entities.extend(
-            DeyeConfigSwitch(coordinator, device, spec)
-            for spec in _FEATURE_FLAG_SWITCHES
-            if _feature_flag_enabled(feature_config, spec)
-        )
-    async_add_entities(entities)
+    async_setup_dynamic_entities(hass, entry, async_add_entities, _switch_entities)
 
 
 class DeyeConfigSwitch(DeyeEntity, SwitchEntity):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ python_version = "3.14"
 platform = "linux"
 show_error_codes = true
 follow_imports = "normal"
+# custom_components/ has no __init__.py; without this, mypy maps the
+# integration as both deye_dehumidifier and custom_components.deye_dehumidifier.
+explicit_package_bases = true
 native_parser = true
 local_partial_types = true
 strict_equality = true
@@ -92,6 +95,13 @@ disallow_untyped_decorators = false
 disallow_untyped_defs = false
 warn_return_any = false
 warn_unreachable = false
+disable_error_code = [
+    "annotation-unchecked",
+    "import-not-found",
+    "import-untyped",
+    "arg-type",
+    "method-assign",
+]
 
 # --- Lint / type-check tooling aligned with Home Assistant core ---
 # https://github.com/home-assistant/core/blob/dev/pyproject.toml

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Deye Dehumidifier integration."""

--- a/tests/test_device_lifecycle.py
+++ b/tests/test_device_lifecycle.py
@@ -1,0 +1,280 @@
+"""Tests for dynamic device discovery and stale-device cleanup."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from libdeye.cloud_api import DeyeCloudApiCannotConnectError
+
+from custom_components.deye_dehumidifier import (
+    ConfigEntryData,
+    async_remove_config_entry_device,
+    async_setup_dynamic_entities,
+)
+from custom_components.deye_dehumidifier.const import (
+    DOMAIN,
+    is_dehumidifier_product_type,
+    is_known_dehumidifier_identifier,
+)
+from custom_components.deye_dehumidifier.data_coordinator import (
+    DeyeDeviceListCoordinator,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+def _device_info(
+    device_id: str,
+    mac: str,
+    product_type: str = "dehumidifier",
+    name: str = "Basement",
+) -> dict[str, str]:
+    return {
+        "device_id": device_id,
+        "mac": mac,
+        "product_type": product_type,
+        "device_name": name,
+    }
+
+
+def test_accepts_known_dehumidifier_types() -> None:
+    """Dehumidifier / 除湿机 / 其他 are all matching dehumidifiers."""
+    assert is_dehumidifier_product_type("dehumidifier")
+    assert is_dehumidifier_product_type("除湿机")
+    assert is_dehumidifier_product_type("其他")
+
+
+def test_rejects_other_product_types() -> None:
+    """Heaters and unknown types are ignored."""
+    assert not is_dehumidifier_product_type("heater")
+    assert not is_dehumidifier_product_type("")
+
+
+def test_identifier_present_on_account() -> None:
+    """A MAC still in the cloud list cannot be deleted."""
+    assert is_known_dehumidifier_identifier(
+        {(DOMAIN, "aa:bb"), ("other", "xx")},
+        {"aa:bb"},
+    )
+
+
+def test_identifier_gone_from_account() -> None:
+    """A MAC missing from the cloud list can be deleted."""
+    assert not is_known_dehumidifier_identifier(
+        {(DOMAIN, "aa:bb")},
+        {"cc:dd"},
+    )
+
+
+def test_async_remove_config_entry_device_when_gone() -> None:
+    """Return True when the device is no longer on the account."""
+    hass = MagicMock()
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        runtime_data=SimpleNamespace(device_list=[_device_info("dev-1", "aa:bb")]),
+    )
+    device_entry = SimpleNamespace(identifiers={(DOMAIN, "missing-mac")})
+
+    assert asyncio.run(async_remove_config_entry_device(hass, entry, device_entry))
+
+
+def test_async_remove_config_entry_device_when_present() -> None:
+    """Return False while the device is still on the account."""
+    hass = MagicMock()
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        runtime_data=SimpleNamespace(device_list=[_device_info("dev-1", "aa:bb")]),
+    )
+    device_entry = SimpleNamespace(identifiers={(DOMAIN, "aa:bb")})
+
+    assert not asyncio.run(async_remove_config_entry_device(hass, entry, device_entry))
+
+
+def test_async_remove_config_entry_device_without_runtime_data() -> None:
+    """Allow deletion when the integration has already been unloaded."""
+    hass = MagicMock()
+    entry = SimpleNamespace(entry_id="entry-1")
+    device_entry = SimpleNamespace(identifiers={(DOMAIN, "aa:bb")})
+
+    assert asyncio.run(async_remove_config_entry_device(hass, entry, device_entry))
+
+
+def _make_list_coordinator() -> DeyeDeviceListCoordinator:
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    with patch(
+        "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+        return_value=None,
+    ):
+        coordinator = DeyeDeviceListCoordinator(hass, entry, MagicMock(), {}, [])
+    coordinator.hass = hass
+    coordinator.config_entry = entry
+    coordinator._initial_sync = False
+    return coordinator
+
+
+def _cloud_device(device_id: str, mac: str) -> MagicMock:
+    device = MagicMock()
+    device.device_id = device_id
+    device.name = f"Device {device_id}"
+    device.info = _device_info(device_id, mac)
+    return device
+
+
+def test_adds_coordinator_for_new_device() -> None:
+    """A new matching dehumidifier gets a coordinator."""
+    coordinator = _make_list_coordinator()
+    new_device = _cloud_device("dev-new", "mac-new")
+    device_coordinator = MagicMock()
+    device_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.DeyeDataUpdateCoordinator",
+        return_value=device_coordinator,
+    ):
+        asyncio.run(coordinator._async_sync_devices([new_device]))
+
+    assert "dev-new" in coordinator.coordinator_map
+    assert coordinator.device_list[0]["mac"] == "mac-new"
+
+
+def test_failed_discovery_does_not_join_device_list() -> None:
+    """A failed first refresh must not leave a device without a coordinator."""
+    coordinator = _make_list_coordinator()
+    new_device = _cloud_device("dev-new", "mac-new")
+    device_coordinator = MagicMock()
+    device_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady
+    )
+    device_coordinator.async_shutdown = AsyncMock()
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.DeyeDataUpdateCoordinator",
+        return_value=device_coordinator,
+    ):
+        asyncio.run(coordinator._async_sync_devices([new_device]))
+
+    assert "dev-new" not in coordinator.coordinator_map
+    assert coordinator.device_list == []
+    device_coordinator.async_shutdown.assert_awaited_once()
+
+
+def test_removes_stale_device_from_registry() -> None:
+    """A device missing from the cloud list is removed via HA 2026.8 APIs."""
+    coordinator = _make_list_coordinator()
+    stale = MagicMock()
+    stale.device.info = _device_info("dev-old", "mac-old")
+    stale.async_shutdown = AsyncMock()
+    coordinator.coordinator_map["dev-old"] = stale
+    coordinator.device_list.append(stale.device.info)
+
+    registry = MagicMock()
+    device_entry = MagicMock()
+    device_entry.id = "registry-id"
+    registry.async_get_device_by_identifier.return_value = device_entry
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.dr.async_get",
+        return_value=registry,
+    ):
+        asyncio.run(coordinator._async_sync_devices([]))
+
+    stale.async_shutdown.assert_awaited_once()
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, "mac-old"), "entry-1"
+    )
+    registry.async_remove_device.assert_called_once_with("registry-id")
+    assert "dev-old" not in coordinator.coordinator_map
+    assert coordinator.device_list == []
+
+
+def test_failed_cloud_fetch_does_not_drop_devices() -> None:
+    """A failed list refresh must not treat every device as stale."""
+    coordinator = _make_list_coordinator()
+    existing = MagicMock()
+    coordinator.coordinator_map["dev-1"] = existing
+    coordinator.device_list.append(_device_info("dev-1", "mac-1"))
+    coordinator._client.list_devices = AsyncMock(
+        side_effect=DeyeCloudApiCannotConnectError
+    )
+
+    try:
+        asyncio.run(coordinator._async_update_data())
+    except UpdateFailed:
+        pass
+    else:
+        raise AssertionError("expected UpdateFailed")
+
+    assert "dev-1" in coordinator.coordinator_map
+    assert coordinator.device_list[0]["device_id"] == "dev-1"
+
+
+def _runtime_entry(
+    device_list: list[dict[str, str]],
+    coordinators: dict[str, MagicMock],
+    list_coordinator: MagicMock,
+) -> SimpleNamespace:
+    entry = SimpleNamespace(entry_id="entry-1")
+    entry.runtime_data = ConfigEntryData(
+        client=MagicMock(),
+        device_list=device_list,
+        coordinator_map=coordinators,
+        device_list_coordinator=list_coordinator,
+    )
+    entry.async_on_unload = MagicMock()
+    return entry
+
+
+def test_listener_adds_only_new_devices() -> None:
+    """The captured async_add_entities callback is used for later devices."""
+    hass = MagicMock()
+    first = _device_info("dev-1", "mac-1")
+    second = _device_info("dev-2", "mac-2")
+    coordinators = {"dev-1": MagicMock(), "dev-2": MagicMock()}
+    list_coordinator = MagicMock()
+    listener_holder: list = []
+
+    def _add_listener(listener):
+        listener_holder.append(listener)
+        return lambda: None
+
+    list_coordinator.async_add_listener.side_effect = _add_listener
+    entry = _runtime_entry([first], coordinators, list_coordinator)
+    added: list[list[object]] = []
+
+    async_setup_dynamic_entities(
+        hass,
+        entry,
+        added.append,
+        lambda coordinator, device: [f"{device['device_id']}:{id(coordinator)}"],
+    )
+
+    assert len(added) == 1
+    assert added[0][0] == f"dev-1:{id(coordinators['dev-1'])}"
+
+    entry.runtime_data.device_list.extend([second])
+    listener_holder[0]()
+
+    assert len(added) == 2
+    assert added[1][0] == f"dev-2:{id(coordinators['dev-2'])}"
+
+
+def test_listener_skips_devices_without_coordinator() -> None:
+    """A device list row without a coordinator must not abort entity setup."""
+    hass = MagicMock()
+    first = _device_info("dev-1", "mac-1")
+    orphan = _device_info("dev-orphan", "mac-orphan")
+    coordinators = {"dev-1": MagicMock()}
+    list_coordinator = MagicMock()
+    entry = _runtime_entry([first, orphan], coordinators, list_coordinator)
+    added: list[list[object]] = []
+
+    async_setup_dynamic_entities(
+        hass,
+        entry,
+        added.append,
+        lambda coordinator, device: [device["device_id"]],
+    )
+
+    assert added == [["dev-1"]]


### PR DESCRIPTION
## Summary

Devices were only loaded in `async_setup_entry`. A new dehumidifier on the Deye account required a reload, and the device page could not delete leftover devices.

This implements Home Assistant gold quality-scale **`dynamic-devices`** and **`stale-devices`** on the existing single config entry (`hass.data`). It does **not** introduce config subentries.

- `DeyeDeviceListCoordinator` re-fetches `client.list_devices()` every 5 minutes and keeps the same product_type filter as setup (`dehumidifier` / `除湿机` / `其他`).
- New matching devices get a per-device coordinator; platforms add entities through the `async_add_entities` callback captured at platform setup (`async_setup_dynamic_entities`).
- Devices that disappear from the cloud list are removed with `DeviceRegistry.async_remove_device()` after lookup via `async_get_device_by_identifier((DOMAIN, mac), entry.entry_id)` (HA 2026.8; not the deprecated `async_get_device()` / `remove_config_entry_id` path).
- `async_remove_config_entry_device` in `__init__.py` enables the UI delete button and returns `True` only when the device is gone from the current account list.
- A failed cloud list refresh raises `UpdateFailed` and does **not** treat every device as stale.

## Test plan

- [x] Unit tests in `tests/test_device_lifecycle.py`: product_type filter, UI delete allow/deny, add new device, remove stale device via 2026.8 registry APIs, failed fetch does not drop devices, platform listener adds only new devices
- [x] `uv run ruff check` / `ruff format` / `pre-commit run --all-files`
- [x] `uv run mypy .`
- [x] `uv run pylint custom_components`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config-entry lifecycle, periodic cloud sync, and automatic device-registry removal; mistakes could drop entities or block legitimate deletes, though failure paths and tests mitigate that.
> 
> **Overview**
> Adds **dynamic device discovery** and **stale device cleanup** so the integration no longer requires a reload when the Deye account changes.
> 
> Setup now drives device loading through **`DeyeDeviceListCoordinator`**, which polls the cloud device list every five minutes, filters the same dehumidifier `product_type` values, and creates or tears down per-device coordinators. Failed list refreshes raise **`UpdateFailed`** and leave existing devices in place. Devices that disappear from the account are removed from the Home Assistant device registry (with a fallback for older registry APIs).
> 
> **`async_setup_dynamic_entities`** registers platform entities at setup and again when new devices appear; humidifier, sensor, switch, binary_sensor, and fan platforms all use it. **`async_remove_config_entry_device`** allows the UI delete action only when the MAC is no longer on the current account list.
> 
> Product-type and identifier helpers move to **`const.py`**. Unload/shutdown paths now **`async_shutdown`** the list coordinator and device coordinators. Unit tests cover discovery, stale removal, failed fetch behavior, and dynamic entity listeners; **`pyproject.toml`** gets mypy tweaks for the new test package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6144fe7a52cc4084313370a9c5c3505249d6058. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->