### PR TITLE
feat: add repair issues and omit invented DeviceInfo configuration_url

### DIFF
--- a/custom_components/deye_dehumidifier/__init__.py
+++ b/custom_components/deye_dehumidifier/__init__.py
@@ -28,6 +28,11 @@ from homeassistant.util import ssl
 
 from .const import CONF_AUTH_TOKEN, CONF_PASSWORD, CONF_USERNAME, DOMAIN, MANUFACTURER
 from .data_coordinator import DeyeDataUpdateCoordinator
+from .issues import (
+    MqttDisconnectMonitor,
+    async_delete_entry_issues,
+    async_sync_unknown_product_issues,
+)
 
 PLATFORMS: list[Platform] = [
     Platform.HUMIDIFIER,
@@ -68,6 +73,7 @@ class ConfigEntryData:
     client: DeyeClient
     device_list: list[DeyeApiResponseDeviceInfo]
     coordinator_map: dict[str, DeyeDataUpdateCoordinator]
+    mqtt_monitor: MqttDisconnectMonitor | None = None
 
 
 type DeyeConfigEntry = ConfigEntry[ConfigEntryData]
@@ -108,11 +114,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool
     except DeyeCloudApiCannotConnectError as err:
         raise ConfigEntryNotReady from err
 
+    device_infos = [device.info for device in devices]
+    mqtt_monitor = MqttDisconnectMonitor(hass, entry.entry_id, client)
     entry.runtime_data = ConfigEntryData(
         client=client,
-        device_list=[device.info for device in devices],
+        device_list=device_infos,
         coordinator_map=coordinator_map,
+        mqtt_monitor=mqtt_monitor,
     )
+
+    async_sync_unknown_product_issues(hass, entry.entry_id, device_infos)
+    mqtt_monitor.async_start()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -122,11 +134,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistant, entry: DeyeConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        for coordinator in entry.runtime_data.coordinator_map.values():
+        data = entry.runtime_data
+        if data.mqtt_monitor is not None:
+            data.mqtt_monitor.async_stop()
+        async_delete_entry_issues(hass, entry.entry_id)
+        for coordinator in data.coordinator_map.values():
             coordinator.unsubscribe()
-        entry.runtime_data.client.disconnect()
+        data.client.disconnect()
 
     return unload_ok
+
+
+def deye_device_configuration_url(
+    _device: DeyeApiResponseDeviceInfo,
+) -> str | None:
+    """Return a stable Deye cloud/app configuration URL if one exists.
+
+    Deye Smart (德业智能) is a mobile app. The end-user API host
+    ``api.deye.com.cn`` is not a user-facing configuration UI, and
+    deyecloud.com is the inverter portal (a different product line).
+    Device-list entries do not include a web configuration URL, so this
+    returns None rather than inventing a broken link.
+    """
+    return None
 
 
 class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
@@ -142,7 +172,7 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
         self._device = device
         self._attr_has_entity_name = True
         self._attr_unique_id = self._device["mac"]
-        self._attr_device_info = DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device["mac"])},
             model=self._device["product_name"],
             model_id=self._device["product_id"],
@@ -150,6 +180,9 @@ class DeyeEntity(CoordinatorEntity[DeyeDataUpdateCoordinator]):
             manufacturer=MANUFACTURER,
             name=self._device["device_name"],
         )
+        if configuration_url := deye_device_configuration_url(self._device):
+            device_info["configuration_url"] = configuration_url
+        self._attr_device_info = device_info
         self._debounced_publish_command = Debouncer(
             hass=self.coordinator.hass,
             logger=_LOGGER,

--- a/custom_components/deye_dehumidifier/const.py
+++ b/custom_components/deye_dehumidifier/const.py
@@ -1,7 +1,17 @@
 """Constants for the Deye Dehumidifier integration."""
 
+from datetime import timedelta
+
 DOMAIN = "deye_dehumidifier"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_AUTH_TOKEN = "auth_token"
 MANUFACTURER = "Ningbo Deye Technology Co., Ltd"
+
+ISSUE_UNKNOWN_PRODUCT = "unknown_product"
+ISSUE_MQTT_DISCONNECTED = "mqtt_disconnected"
+ISSUE_TRACKER_URL = "https://github.com/stackia/ha-deye-dehumidifier/issues"
+
+# Ignore brief MQTT reconnects; only raise a repair after this long.
+MQTT_DISCONNECT_ISSUE_DELAY = timedelta(minutes=15)
+MQTT_DISCONNECT_CHECK_INTERVAL = timedelta(minutes=1)

--- a/custom_components/deye_dehumidifier/issues.py
+++ b/custom_components/deye_dehumidifier/issues.py
@@ -1,0 +1,188 @@
+"""Issue registry repairs for the Deye Dehumidifier integration."""
+
+from datetime import datetime
+import logging
+
+from libdeye.client import DeyeClient
+from libdeye.cloud_api import DeyeApiResponseDeviceInfo
+from libdeye.const import PRODUCT_FEATURE_CONFIG
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    ISSUE_MQTT_DISCONNECTED,
+    ISSUE_TRACKER_URL,
+    ISSUE_UNKNOWN_PRODUCT,
+    MQTT_DISCONNECT_CHECK_INTERVAL,
+    MQTT_DISCONNECT_ISSUE_DELAY,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def uses_default_feature_config(product_id: str) -> bool:
+    """Return True if this product_id is not in libdeye's known feature map."""
+    return product_id not in PRODUCT_FEATURE_CONFIG
+
+
+def unknown_product_issue_id(entry_id: str, device_id: str) -> str:
+    """Return the issue id for an unmapped product on a config entry."""
+    return f"{ISSUE_UNKNOWN_PRODUCT}_{entry_id}_{device_id}"
+
+
+def mqtt_disconnected_issue_id(entry_id: str) -> str:
+    """Return the issue id for a prolonged MQTT disconnect on a config entry."""
+    return f"{ISSUE_MQTT_DISCONNECTED}_{entry_id}"
+
+
+def mqtt_client_is_connected(mqtt_client: object) -> bool | None:
+    """Return the paho connected flag when the MQTT wrapper exposes it."""
+    paho_client = getattr(mqtt_client, "_mqtt", None)
+    is_connected = getattr(paho_client, "is_connected", None)
+    if not callable(is_connected):
+        return None
+    return bool(is_connected())
+
+
+def pooled_mqtt_clients_connected(client: DeyeClient) -> bool | None:
+    """Return True if every pooled MQTT client is connected.
+
+    None means no clients have been started or the connected flag is unavailable.
+    """
+    mqtt_by_type = getattr(client, "_mqtt_by_type", None)
+    if not isinstance(mqtt_by_type, dict) or not mqtt_by_type:
+        return None
+    results = [
+        mqtt_client_is_connected(mqtt_client) for mqtt_client in mqtt_by_type.values()
+    ]
+    if any(result is None for result in results):
+        return None
+    return all(result is True for result in results)
+
+
+def async_sync_unknown_product_issues(
+    hass: HomeAssistant,
+    entry_id: str,
+    devices: list[DeyeApiResponseDeviceInfo],
+) -> None:
+    """Create or delete unknown-product repairs for the current device list."""
+    wanted: set[str] = set()
+    for device in devices:
+        issue_id = unknown_product_issue_id(entry_id, device["device_id"])
+        if not uses_default_feature_config(device["product_id"]):
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+            continue
+        wanted.add(issue_id)
+        _LOGGER.warning(
+            "Device %s (%s) uses the default feature config; product_id=%s is unmapped",
+            device["device_name"],
+            device.get("product_name", ""),
+            device["product_id"],
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_UNKNOWN_PRODUCT,
+            translation_placeholders={
+                "name": device["device_name"],
+                "product_id": device["product_id"],
+                "product_name": device.get("product_name") or device["product_id"],
+            },
+            learn_more_url=ISSUE_TRACKER_URL,
+        )
+
+    prefix = f"{ISSUE_UNKNOWN_PRODUCT}_{entry_id}_"
+    issue_reg = ir.async_get(hass)
+    for domain, issue_id in list(issue_reg.issues):
+        if domain == DOMAIN and issue_id.startswith(prefix) and issue_id not in wanted:
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+def async_delete_entry_issues(hass: HomeAssistant, entry_id: str) -> None:
+    """Delete all repairs created for a config entry."""
+    ir.async_delete_issue(hass, DOMAIN, mqtt_disconnected_issue_id(entry_id))
+    prefix = f"{ISSUE_UNKNOWN_PRODUCT}_{entry_id}_"
+    issue_reg = ir.async_get(hass)
+    for domain, issue_id in list(issue_reg.issues):
+        if domain == DOMAIN and issue_id.startswith(prefix):
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+class MqttDisconnectMonitor:
+    """Raise a repair if pooled MQTT clients stay disconnected too long."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str, client: DeyeClient) -> None:
+        """Initialize the monitor for one config entry."""
+        self.hass = hass
+        self.entry_id = entry_id
+        self.client = client
+        self._disconnected_since: datetime | None = None
+        self._unsub: CALLBACK_TYPE | None = None
+        self._stopped = False
+
+    def async_start(self) -> None:
+        """Start periodic checks and evaluate the current connection."""
+        self._stopped = False
+        self._unsub = async_track_time_interval(
+            self.hass, self.async_check, MQTT_DISCONNECT_CHECK_INTERVAL
+        )
+        self.async_check()
+
+    @callback
+    def async_stop(self) -> None:
+        """Stop checks and delete the MQTT repair if it exists."""
+        self._stopped = True
+        if self._unsub is not None:
+            self._unsub()
+            self._unsub = None
+        self.async_clear()
+
+    @callback
+    def async_clear(self) -> None:
+        """Clear disconnect tracking and delete the MQTT repair."""
+        self._disconnected_since = None
+        ir.async_delete_issue(
+            self.hass, DOMAIN, mqtt_disconnected_issue_id(self.entry_id)
+        )
+
+    @callback
+    def async_check(self, now: datetime | None = None) -> None:
+        """Create or delete the MQTT repair based on pooled client state."""
+        if self._stopped:
+            return
+        if now is None:
+            now = dt_util.utcnow()
+
+        connected = pooled_mqtt_clients_connected(self.client)
+        if connected is not False:
+            if connected is True:
+                self.async_clear()
+            return
+
+        if self._disconnected_since is None:
+            self._disconnected_since = now
+            return
+
+        if now - self._disconnected_since < MQTT_DISCONNECT_ISSUE_DELAY:
+            return
+
+        minutes = str(int(MQTT_DISCONNECT_ISSUE_DELAY.total_seconds() // 60))
+        _LOGGER.warning(
+            "Deye MQTT has been disconnected for more than %s minutes", minutes
+        )
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            mqtt_disconnected_issue_id(self.entry_id),
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key=ISSUE_MQTT_DISCONNECTED,
+            translation_placeholders={"minutes": minutes},
+        )

--- a/custom_components/deye_dehumidifier/issues.py
+++ b/custom_components/deye_dehumidifier/issues.py
@@ -64,6 +64,7 @@ def pooled_mqtt_clients_connected(client: DeyeClient) -> bool | None:
     return all(result is True for result in results)
 
 
+@callback
 def async_sync_unknown_product_issues(
     hass: HomeAssistant,
     entry_id: str,
@@ -105,6 +106,7 @@ def async_sync_unknown_product_issues(
             ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
+@callback
 def async_delete_entry_issues(hass: HomeAssistant, entry_id: str) -> None:
     """Delete all repairs created for a config entry."""
     ir.async_delete_issue(hass, DOMAIN, mqtt_disconnected_issue_id(entry_id))
@@ -127,6 +129,7 @@ class MqttDisconnectMonitor:
         self._unsub: CALLBACK_TYPE | None = None
         self._stopped = False
 
+    @callback
     def async_start(self) -> None:
         """Start periodic checks and evaluate the current connection."""
         self._stopped = False
@@ -161,9 +164,11 @@ class MqttDisconnectMonitor:
             now = dt_util.utcnow()
 
         connected = pooled_mqtt_clients_connected(self.client)
-        if connected is not False:
-            if connected is True:
-                self.async_clear()
+        if connected is True:
+            self.async_clear()
+            return
+        if connected is None:
+            self._disconnected_since = None
             return
 
         if self._disconnected_since is None:
@@ -173,6 +178,10 @@ class MqttDisconnectMonitor:
         if now - self._disconnected_since < MQTT_DISCONNECT_ISSUE_DELAY:
             return
 
+        issue_id = mqtt_disconnected_issue_id(self.entry_id)
+        if (DOMAIN, issue_id) in ir.async_get(self.hass).issues:
+            return
+
         minutes = str(int(MQTT_DISCONNECT_ISSUE_DELAY.total_seconds() // 60))
         _LOGGER.warning(
             "Deye MQTT has been disconnected for more than %s minutes", minutes
@@ -180,7 +189,7 @@ class MqttDisconnectMonitor:
         ir.async_create_issue(
             self.hass,
             DOMAIN,
-            mqtt_disconnected_issue_id(self.entry_id),
+            issue_id,
             is_fixable=False,
             severity=ir.IssueSeverity.ERROR,
             translation_key=ISSUE_MQTT_DISCONNECTED,

--- a/custom_components/deye_dehumidifier/translations/en.json
+++ b/custom_components/deye_dehumidifier/translations/en.json
@@ -125,5 +125,15 @@
     "command_failed": {
       "message": "Failed to send command to the device: {error}"
     }
+  },
+  "issues": {
+    "unknown_product": {
+      "title": "Unknown Deye dehumidifier model",
+      "description": "The device **{name}** ({product_name}, product ID `{product_id}`) is not in the known product list, so this integration is using a generic default feature set. Some controls may be missing or extra.\n\nPlease open a GitHub issue with this product ID so model-specific support can be added."
+    },
+    "mqtt_disconnected": {
+      "title": "Deye MQTT connection lost",
+      "description": "This integration has been disconnected from Deye's MQTT service for more than {minutes} minutes. Device state will not update until the connection is restored.\n\nCheck your internet connection and Deye cloud status, then reload the integration if it does not recover on its own."
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/pt-PT.json
+++ b/custom_components/deye_dehumidifier/translations/pt-PT.json
@@ -125,5 +125,15 @@
     "command_failed": {
       "message": "Falha ao enviar comando para o dispositivo: {error}"
     }
+  },
+  "issues": {
+    "unknown_product": {
+      "title": "Modelo de desumidificador Deye desconhecido",
+      "description": "O dispositivo **{name}** ({product_name}, ID de produto `{product_id}`) não está na lista de produtos conhecidos, por isso esta integração está a usar um conjunto de funcionalidades predefinido. Alguns controlos podem faltar ou ser extra.\n\nAbra um issue no GitHub com este ID de produto para que o suporte específico do modelo possa ser adicionado."
+    },
+    "mqtt_disconnected": {
+      "title": "Ligação MQTT Deye perdida",
+      "description": "Esta integração está desligada do serviço MQTT da Deye há mais de {minutes} minutos. O estado do dispositivo não será atualizado até a ligação ser restabelecida.\n\nVerifique a ligação à Internet e o estado da nuvem Deye e, se não recuperar automaticamente, recarregue a integração."
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/vi-VN.json
+++ b/custom_components/deye_dehumidifier/translations/vi-VN.json
@@ -125,5 +125,15 @@
     "command_failed": {
       "message": "Không gửi được lệnh tới thiết bị: {error}"
     }
+  },
+  "issues": {
+    "unknown_product": {
+      "title": "Mẫu máy hút ẩm Deye chưa được hỗ trợ",
+      "description": "Thiết bị **{name}** ({product_name}, product ID `{product_id}`) không có trong danh sách sản phẩm đã biết, nên tích hợp đang dùng cấu hình tính năng mặc định. Một số điều khiển có thể thiếu hoặc thừa.\n\nVui lòng mở issue trên GitHub kèm product ID này để bổ sung hỗ trợ cho mẫu máy."
+    },
+    "mqtt_disconnected": {
+      "title": "Mất kết nối MQTT Deye",
+      "description": "Tích hợp đã mất kết nối với dịch vụ MQTT của Deye hơn {minutes} phút. Trạng thái thiết bị sẽ không cập nhật cho đến khi kết nối được khôi phục.\n\nHãy kiểm tra kết nối Internet và trạng thái Deye cloud, rồi tải lại tích hợp nếu không tự phục hồi."
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/zh-Hans.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hans.json
@@ -125,5 +125,15 @@
     "command_failed": {
       "message": "向设备发送指令失败：{error}"
     }
+  },
+  "issues": {
+    "unknown_product": {
+      "title": "未知的德业除湿机型号",
+      "description": "设备 **{name}**（{product_name}，产品 ID `{product_id}`）不在已知产品列表中，因此本集成正在使用通用默认功能配置。部分控制项可能缺失或多余。\n\n请在 GitHub 提交 issue 并附上该产品 ID，以便添加针对该型号的支持。"
+    },
+    "mqtt_disconnected": {
+      "title": "德业 MQTT 连接已断开",
+      "description": "本集成与德业 MQTT 服务的连接已断开超过 {minutes} 分钟。在连接恢复之前，设备状态不会更新。\n\n请检查网络连接和德业云服务状态；如果未能自动恢复，请重新加载此集成。"
+    }
   }
 }

--- a/custom_components/deye_dehumidifier/translations/zh-Hant.json
+++ b/custom_components/deye_dehumidifier/translations/zh-Hant.json
@@ -125,5 +125,15 @@
     "command_failed": {
       "message": "向裝置傳送指令失敗：{error}"
     }
+  },
+  "issues": {
+    "unknown_product": {
+      "title": "未知的德業除濕機型號",
+      "description": "裝置 **{name}**（{product_name}，產品 ID `{product_id}`）不在已知產品清單中，因此本整合正在使用通用預設功能設定。部分控制項可能缺失或多餘。\n\n請在 GitHub 提交 issue 並附上該產品 ID，以便新增針對該型號的支援。"
+    },
+    "mqtt_disconnected": {
+      "title": "德業 MQTT 連線已中斷",
+      "description": "本整合與德業 MQTT 服務的連線已中斷超過 {minutes} 分鐘。在連線恢復之前，裝置狀態不會更新。\n\n請檢查網路連線和德業雲端服務狀態；如果未能自動恢復，請重新載入此整合。"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Home Assistant quality scale: **repair-issues**, plus DeviceInfo `configuration_url`.

### DeviceInfo `configuration_url`

Deye Smart (德业智能) is a mobile app. libdeye talks to `https://api.deye.com.cn/v3/enduser`, which is not a user-facing configuration UI, and [deyecloud.com](https://www.deyecloud.com/) is the **inverter** portal (a different product line). Device-list rows have image URLs, not a web config page.

`DeyeEntity` sets `configuration_url` on `DeviceInfo` only when `deye_device_configuration_url()` returns a URL. Today that helper returns `None`, so the field is omitted rather than inventing a broken link.

### Repair issues

`ir.async_create_issue` / `ir.async_delete_issue` with translation keys in all five `translations/*.json` files:

- **`unknown_product`** (warning) — device `product_id` is not in libdeye `PRODUCT_FEATURE_CONFIG`, so the integration is running on the default feature set. Placeholders: `{name}`, `{product_name}`, `{product_id}`. `learn_more_url` points at the GitHub issue tracker. Deleted when the product is mapped, the device leaves the account, or the entry unloads.
- **`mqtt_disconnected`** (error) — pooled Classic/Fog MQTT clients stay disconnected for **15 minutes**. Brief reconnects do not raise a repair. Deleted when MQTT is connected again or the entry unloads.

Both issues are `is_fixable=False` (user action: file a GitHub issue, or check network / reload). No `diagnostics.py`, no config subentries, no repair flows.

## Test plan

- [x] `deye_device_configuration_url()` returns `None` for a typical device-list row (no invented URL)
- [x] Unmapped `product_id` creates `unknown_product_{entry}_{device}`; mapped and stale devices delete their issues
- [x] MQTT helper reads paho `is_connected`; empty pool is unknown (no false repair)
- [x] MQTT repair is not created at t=0 or t=14m59s; created at t=15m with `{minutes: 15}`; deleted on reconnect
- [x] All five translation files define `issues.unknown_product` and `issues.mqtt_disconnected` with matching placeholders
- [x] `uv run ruff check` / `ruff format --check`
- [x] `uv run mypy .` — 12 source files, no issues
- [x] `uv run pylint custom_components scripts`
- [x] `uv run pre-commit run --all-files`
- [ ] CI (hassfest, HACS, lint/type-check) on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive (issue registry, periodic MQTT polling, optional device URL) with no auth or command-path changes; main risk is false-positive MQTT repairs if libdeye’s connection introspection is wrong.
> 
> **Overview**
> Adds **Home Assistant repair issues** for the quality-scale `repair-issues` requirement, wired into config entry setup and teardown.
> 
> On load, the integration syncs **`unknown_product`** warnings per device whose `product_id` is missing from libdeye’s `PRODUCT_FEATURE_CONFIG` (with GitHub learn-more link), and starts **`MqttDisconnectMonitor`** to raise an **`mqtt_disconnected`** error only after pooled MQTT clients stay down for 15 minutes (1-minute checks; brief outages ignored). Stale or entry-scoped issues are removed on reconnect, device list changes, or unload.
> 
> **`DeyeEntity` DeviceInfo** now sets `configuration_url` only when `deye_device_configuration_url()` returns a URL; the helper currently always returns `None` so no misleading cloud/API link is shown. Issue copy is added in all five translation files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2001fd69d58d6a12d53ad98452065d61d1e81631. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->