### PR TITLE
fix: post-merge review follow-ups for reauth input, icons, and diagnostics

### DIFF
--- a/custom_components/deye_dehumidifier/config_flow.py
+++ b/custom_components/deye_dehumidifier/config_flow.py
@@ -140,7 +140,7 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
                 data_schema=STEP_REAUTH_DATA_SCHEMA,
                 description_placeholders={"username": username},
             )
-        user_input[CONF_USERNAME] = username
+        user_input = {**user_input, CONF_USERNAME: username}
         result = await validate_input(self.hass, user_input)
         if "errors" in result:
             return self.async_show_form(
@@ -172,7 +172,7 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
                 data_schema=STEP_REAUTH_DATA_SCHEMA,
                 description_placeholders={"username": username},
             )
-        user_input[CONF_USERNAME] = username
+        user_input = {**user_input, CONF_USERNAME: username}
         result = await validate_input(self.hass, user_input)
         if "errors" in result:
             return self.async_show_form(

--- a/custom_components/deye_dehumidifier/diagnostics.py
+++ b/custom_components/deye_dehumidifier/diagnostics.py
@@ -225,6 +225,16 @@ async def async_get_config_entry_diagnostics(
                 "version": entry.version,
                 "data": dict(entry.data),
                 "options": dict(entry.options),
+                "subentries": [
+                    {
+                        "subentry_id": subentry.subentry_id,
+                        "subentry_type": subentry.subentry_type,
+                        "title": subentry.title,
+                        "unique_id": subentry.unique_id,
+                        "data": dict(subentry.data),
+                    }
+                    for subentry in entry.subentries.values()
+                ],
             },
             "mqtt_clients": _mqtt_clients_snapshot(data.client),
             "devices": [

--- a/custom_components/deye_dehumidifier/icons.json
+++ b/custom_components/deye_dehumidifier/icons.json
@@ -10,7 +10,10 @@
               "sleep": "mdi:power-sleep",
               "air_purifier": "mdi:air-purifier",
               "clothes_dryer": "mdi:hanger",
-              "turbo": "mdi:fan-plus"
+              "turbo": "mdi:fan-plus",
+              "manual_purifier": "mdi:air-filter",
+              "sleep_purifier": "mdi:power-sleep",
+              "auto_purifier": "mdi:air-purifier"
             }
           }
         }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.deye_dehumidifier.const import DOMAIN
+from custom_components.deye_dehumidifier.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from tests.helpers import MOCK_CONFIG, MOCK_DEVICE_INFO, FakeDeyeDevice
@@ -40,3 +43,26 @@ async def test_setup_and_unload_entry(
 
     assert entry.state == ConfigEntryState.NOT_LOADED
     client.disconnect.assert_called_once()
+
+
+async def test_config_entry_diagnostics_include_subentries(
+    hass: HomeAssistant, mock_libdeye: tuple[MagicMock, FakeDeyeDevice]
+) -> None:
+    """Diagnostics list configured device subentries without secrets."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="user-123",
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    subentries = diagnostics["entry"]["subentries"]
+    assert len(subentries) == 1
+    assert subentries[0]["unique_id"] == MOCK_DEVICE_INFO["device_id"]
+    assert diagnostics["entry"]["data"]["password"] == "**REDACTED**"
+    assert diagnostics["entry"]["data"]["auth_token"] == "**REDACTED**"


### PR DESCRIPTION
## Summary

Post-merge review of the combined modernization stack on `main`. These are leftover gaps across the landed PRs, not a new feature.

## Fixes
- **Reauth / reconfigure:** copy `user_input` before adding the stored username. HA can pass a `mappingproxy`; mutating it raised `TypeError`.
- **Icons:** add MDI icons for `manual_purifier` / `sleep_purifier` / `auto_purifier` so they match the humidifier translations from the MODE_NORMAL work.
- **Diagnostics:** include device subentry id/title/unique_id/data on config-entry diagnostics so support dumps show which dehumidifiers are configured.

## Already on main (no code change here)
runtime_data, config subentries, dynamic/stale devices, repair issues, omitted `configuration_url`, UnitOfRatio, PARALLEL_UPDATES, fan PRESET_MODE, exception translations, brand images, coordinator `_async_update_data` + MQTT unsubscribe, pytest CI, libdeye paho Callback API v2.

## Test plan
- [x] `uv run pytest` — 28 passed
- [x] `uv run ruff check` / `ruff format --check` / `mypy` / `pylint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bugfix and diagnostics/UI metadata changes with no auth logic redesign; credentials remain redacted in diagnostics.
> 
> **Overview**
> Follow-up fixes from post-merge review: reauth/reconfigure no longer mutate Home Assistant’s read-only `user_input` (e.g. `mappingproxy`), which could raise `TypeError` when injecting the stored username—both flows now merge into a new dict before validation.
> 
> Config-entry **diagnostics** now include a `subentries` list (id, type, title, unique_id, data) so support dumps show which dehumidifiers are configured; a test asserts one subentry and that passwords/tokens stay redacted.
> 
> **Icons** add MDI mappings for `manual_purifier`, `sleep_purifier`, and `auto_purifier` humidifier modes to align with existing translations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67839358df594d13bc384436a2ed9546f89307e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->