### PR TITLE
chore: bump integration version to 3.0.0

### DIFF
--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
   "requirements": ["libdeye==3.0.2"],
-  "version": "2.2.0"
+  "version": "3.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-deye-dehumidifier"
-version = "2.2.0"
+version = "3.0.0"
 description = "Home Assistant integration for Deye Dehumidifier"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "ha-deye-dehumidifier"
-version = "2.2.0"
+version = "3.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "libdeye" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump the HACS integration version from `2.2.0` to `3.0.0` in `manifest.json`, `pyproject.toml`, and `uv.lock`. Latest GitHub release is still `v2.1.8`; this is the first published tag of the 3.x modernization.

After merge, tag `v3.0.0` and publish the GitHub release.

## Breaking changes

- Minimum Home Assistant is **2026.8.3** (Python 3.14).
- Humidifier mode `manual` is now HA built-in **`normal`**. Automations that set `manual` need updating.
- Each dehumidifier is a **config subentry** (config entry version 2). Existing accounts migrate on setup.
- The integration no longer sets `entity_id`; Home Assistant generates it.
- Runtime dependency is `libdeye==3.0.2`.

## What's included since v2.1.8

- Drive devices through `DeyeClient`; UV / prompt sound / screen display switches when the product advertises them
- Reauth helpers and a reconfigure flow
- Diagnostics (credentials redacted; subentries included)
- Fan preset modes (`low` / `medium` / `high` / `full` / `auto`)
- Translated command errors
- Official brand images
- Repair issues for unknown products and prolonged MQTT disconnect
- Dynamic discovery of new devices; user-managed add/remove of device subentries
- Pytest coverage for config flow, setup, and entities

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cef1c15-29f5-4a12-a67b-7a55e4e6f689?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cef1c15-29f5-4a12-a67b-7a55e4e6f689&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

