### PR TITLE
chore: bump integration to 3.0.1 and libdeye to 3.0.3

### DIFF
--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/stackia/ha-deye-dehumidifier",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
-  "requirements": ["libdeye==3.0.2"],
-  "version": "3.0.0"
+  "requirements": ["libdeye==3.0.3"],
+  "version": "3.0.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-deye-dehumidifier"
-version = "3.0.0"
+version = "3.0.1"
 description = "Home Assistant integration for Deye Dehumidifier"
 readme = "README.md"
 license = "MIT"
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Home Automation",
 ]
 dependencies = [
-    "libdeye==3.0.2",
+    "libdeye==3.0.3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "ha-deye-dehumidifier"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "libdeye" },
@@ -1165,7 +1165,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "libdeye", specifier = "==3.0.2" }]
+requires-dist = [{ name = "libdeye", specifier = "==3.0.3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1435,16 +1435,16 @@ wheels = [
 
 [[package]]
 name = "libdeye"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "paho-mqtt" },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/a9c41323590d0404c1a6d0b72e927b8d8a7e85c92806e758b809cc684ed5/libdeye-3.0.2.tar.gz", hash = "sha256:777532a9b925619816af5aa1bff1668f312e626530e7cc5d1cd96a45fa59f5e2", size = 840704, upload-time = "2026-09-02T09:51:47.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/8c/126f7f695055cbab0e54e8dbc673dcc25b8991ad72e5ae935c77fa1edab3/libdeye-3.0.3.tar.gz", hash = "sha256:627fa36e0decefbb9cfb86c03c1d9845e38f6518c1d29913ebeaf858a45de223", size = 842856, upload-time = "2026-09-03T08:40:48.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/52/d3fc2cfa198791f4e11ba6f5f62ad8c1cab9b167ab96566c59a9c1574c28/libdeye-3.0.2-py3-none-any.whl", hash = "sha256:a62f4e08c3050ac2ad64eeae40e22b2434148449aa31ac9899844180524c98f2", size = 30087, upload-time = "2026-09-02T09:51:46.385Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/8d85e5650c5a365c625d3d68e44e88e6e7b24c732d21b5c53da35fafbcb3/libdeye-3.0.3-py3-none-any.whl", hash = "sha256:7783a1249c6f0a4f9b9643c98896d227b0b0ccf6c73fb17a377931ac2487fad7", size = 30419, upload-time = "2026-09-03T08:40:47.215Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump the HACS integration to **3.0.1** and pin `libdeye==3.0.3`.

This is the HA-side delivery of libdeye 3.0.3:

- Fog GET / device-list payloads that omit `Demisting`, `WaterTank`, or `Fan` no longer raise `KeyError` (fixes https://github.com/stackia/ha-deye-dehumidifier/issues/134)
- Official product extras (`uv` / `prompt_sound` / `screen_display` / `timed_off`) and corrected ES25A3 / P30 / B13A3 / RT12 product IDs

After merge, tag `v3.0.1` and publish the GitHub release so HACS can pick it up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06642-3518-747c-a25e-de2b99beb33f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06642-3518-747c-a25e-de2b99beb33f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

