### PR TITLE
fix: detect stalled Classic MQTT polls and auto-recover

### DIFF
--- a/custom_components/deye_dehumidifier/const.py
+++ b/custom_components/deye_dehumidifier/const.py
@@ -20,6 +20,14 @@ ISSUE_TRACKER_URL = "https://github.com/stackia/ha-deye-dehumidifier/issues"
 MQTT_DISCONNECT_ISSUE_DELAY = timedelta(minutes=15)
 MQTT_DISCONNECT_CHECK_INTERVAL = timedelta(minutes=1)
 
+# Classic/Combo polls publish MQTT query bytes and must see a real
+# status/hex reply. A single timeout is treated as transient; a second
+# consecutive miss marks entities unavailable and reloads the entry so
+# the pooled MQTT client is destroyed and recreated.
+CLASSIC_STATE_QUERY_TIMEOUT = 12
+CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY = 2
+CLASSIC_RECOVERY_DELAY = 5
+
 # The product_type was initially set to "dehumidifier"
 # but at some point (around 06/18/2025) it was changed to "除湿机" or "其他"
 DEHUMIDIFIER_PRODUCT_TYPES = frozenset({"dehumidifier", "除湿机", "其他"})

--- a/custom_components/deye_dehumidifier/data_coordinator.py
+++ b/custom_components/deye_dehumidifier/data_coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for Deye dehumidifier devices."""
 
+import asyncio
 from datetime import datetime, timedelta
 import logging
 from typing import NamedTuple, override
@@ -9,6 +10,7 @@ from libdeye.cloud_api import (
     DeyeApiResponseDeviceInfo,
     DeyeCloudApiCannotConnectError,
     DeyeCloudApiInvalidAuthError,
+    DeyeDeviceTransport,
 )
 from libdeye.device_state import DeyeDeviceState
 
@@ -19,7 +21,14 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEVICE_LIST_UPDATE_INTERVAL, DOMAIN, is_dehumidifier_product_type
+from .const import (
+    CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY,
+    CLASSIC_RECOVERY_DELAY,
+    CLASSIC_STATE_QUERY_TIMEOUT,
+    DEVICE_LIST_UPDATE_INTERVAL,
+    DOMAIN,
+    is_dehumidifier_product_type,
+)
 from .subentries import configured_device_ids
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,6 +91,10 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
         self.state_update_muted: CALLBACK_TYPE | None = None
         self._unsubscribers: list[CALLBACK_TYPE] = []
         self._unavailable_logged = False
+        self._classic_query_failures = 0
+        self._poll_forced_unavailable = False
+        self._classic_reload_unsub: CALLBACK_TYPE | None = None
+        self._classic_poll_waiter: asyncio.Future[DeyeDeviceState] | None = None
 
     @override
     async def _async_setup(self) -> None:
@@ -112,6 +125,11 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
         if self.state_update_muted:
             self.state_update_muted()
             self.state_update_muted = None
+        self._cancel_classic_recovery()
+        waiter = self._classic_poll_waiter
+        if waiter is not None and not waiter.done():
+            waiter.cancel()
+        self._classic_poll_waiter = None
 
     @override
     async def async_shutdown(self) -> None:
@@ -132,18 +150,26 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
 
     def update_device_state(self, state: DeyeDeviceState) -> None:
         """Will be called when received new DeyeDeviceState."""
+        recovered = self._classic_query_failures > 0 or self._poll_forced_unavailable
+        self._clear_classic_query_failure()
+        waiter = self._classic_poll_waiter
+        if waiter is not None and not waiter.done():
+            waiter.set_result(state)
+            return
         if self.state_update_muted:
             return
         self.async_set_updated_data(
             DeyeDeviceData(
                 reported_state=state,
                 state=state.copy(),
-                available=self.data.available,
+                available=True if recovered else self.data.available,
             )
         )
 
     def update_device_availability(self, available: bool) -> None:
         """Will be called when received device availability change."""
+        if self._poll_forced_unavailable and available:
+            return
         self._log_availability(available)
         self.async_set_updated_data(
             DeyeDeviceData(
@@ -172,19 +198,108 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
             available=self.data.available,
         )
 
+    def _clear_classic_query_failure(self) -> None:
+        """Reset Classic poll-failure tracking and cancel a pending reload."""
+        if self._classic_query_failures:
+            _LOGGER.info(
+                "Classic MQTT state updates recovered for %s after %s "
+                "consecutive failure(s)",
+                self.name,
+                self._classic_query_failures,
+            )
+        self._classic_query_failures = 0
+        self._poll_forced_unavailable = False
+        self._cancel_classic_recovery()
+
+    @callback
+    def _cancel_classic_recovery(self) -> None:
+        """Cancel a pending config-entry reload."""
+        if self._classic_reload_unsub is None:
+            return
+        self._classic_reload_unsub()
+        self._classic_reload_unsub = None
+
+    def _schedule_classic_recovery(self) -> None:
+        """Reload the config entry so the pooled MQTT client is recreated."""
+        if self._classic_reload_unsub is not None or self.config_entry is None:
+            return
+
+        @callback
+        def _reload(_now: datetime) -> None:
+            self._classic_reload_unsub = None
+            if self.config_entry is None:
+                return
+            entry_id = self.config_entry.entry_id
+            _LOGGER.warning(
+                "Reloading Deye config entry after %s consecutive Classic "
+                "MQTT state query failures for %s",
+                self._classic_query_failures,
+                self.name,
+            )
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(entry_id),
+                name=f"Reload Deye config entry {entry_id}",
+            )
+
+        self._classic_reload_unsub = async_call_later(
+            self.hass, CLASSIC_RECOVERY_DELAY, _reload
+        )
+
+    def _handle_classic_query_timeout(self) -> DeyeDeviceData:
+        """Keep last state once; then mark unavailable and recover."""
+        self._classic_query_failures += 1
+        _LOGGER.warning(
+            "Classic MQTT state query for %s timed out after %ss "
+            "(%s/%s consecutive failures)",
+            self.name,
+            CLASSIC_STATE_QUERY_TIMEOUT,
+            self._classic_query_failures,
+            CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY,
+        )
+        if self._classic_query_failures < CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY:
+            return self.data
+
+        self._poll_forced_unavailable = True
+        self._schedule_classic_recovery()
+        return DeyeDeviceData(
+            reported_state=self.data.reported_state,
+            state=self.data.state,
+            available=False,
+        )
+
+    async def _async_query_classic_state(self) -> DeyeDeviceState:
+        """Publish a Classic/Combo poll and wait for the next MQTT state."""
+        waiter: asyncio.Future[DeyeDeviceState] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self._classic_poll_waiter = waiter
+        try:
+            await self.device.request_refresh()
+            async with asyncio.timeout(CLASSIC_STATE_QUERY_TIMEOUT):
+                return await waiter
+        finally:
+            self._classic_poll_waiter = None
+
     @override
     async def _async_update_data(self) -> DeyeDeviceData:
         """Poll device state. Some Deye devices have a long heartbeat period.
 
-        Fog uses HTTP ``RealData`` poll; Classic/Combo publish the MQTT query
-        command. Both keep mute-window behavior and wait for MQTT for the
-        next payload when ``request_refresh`` returns ``None``.
+        Fog uses HTTP ``RealData`` poll and returns when the POST succeeds.
+        Classic/Combo publish the MQTT query command and wait for the
+        matching ``status/hex`` payload. A cached return is not treated as
+        proof that MQTT is still working.
         """
         if self.state_update_muted:
             return self.data
 
         try:
-            reported_state = await self.device.request_refresh()
+            if self.device.transport is DeyeDeviceTransport.FOG:
+                reported_state = await self.device.request_refresh()
+            else:
+                try:
+                    reported_state = await self._async_query_classic_state()
+                except TimeoutError:
+                    return self._handle_classic_query_timeout()
         except DeyeCloudApiInvalidAuthError as err:
             raise ConfigEntryAuthFailed from err
         except (DeyeCloudApiCannotConnectError, OSError) as err:
@@ -198,7 +313,7 @@ class DeyeDataUpdateCoordinator(DataUpdateCoordinator[DeyeDeviceData]):
         return DeyeDeviceData(
             reported_state=reported_state,
             state=reported_state.copy(),
-            available=self.data.available,
+            available=True,
         )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,11 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from libdeye.cloud_api import DeyeApiResponseDeviceInfo, DeyeIotPlatform
+from libdeye.cloud_api import (
+    DeyeApiResponseDeviceInfo,
+    DeyeIotPlatform,
+    transport_for_device,
+)
 from libdeye.device_state import DeyeDeviceState
 
 from custom_components.deye_dehumidifier.const import (
@@ -64,12 +68,18 @@ class FakeDeyeDevice:
             payload if isinstance(payload, str) else DEFAULT_STATE_HEX
         )
         self.state = self.reported_state.copy()
+        self.transport = transport_for_device(info)
         self.ensure_connected = AsyncMock(return_value=MagicMock())
-        self.request_refresh = AsyncMock(return_value=None)
+        self.request_refresh = AsyncMock(side_effect=self._async_request_refresh)
         self.apply = AsyncMock()
         self._on_state: Callable[[DeyeDeviceState], None] | None = None
         self._on_availability: Callable[[bool], None] | None = None
         self._unsub: Callable[[], None] = lambda: None
+
+    async def _async_request_refresh(self) -> None:
+        """Deliver the current state to the subscriber, like a healthy MQTT reply."""
+        if self._on_state is not None:
+            self._on_state(self.reported_state)
 
     def subscribe(
         self,

--- a/tests/test_data_coordinator.py
+++ b/tests/test_data_coordinator.py
@@ -1,0 +1,261 @@
+"""Tests for Classic MQTT polling and automatic recovery."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from libdeye.cloud_api import DeyeIotPlatform
+from libdeye.const import COMBO_PROTOCOL_VERSION
+from libdeye.device_state import DeyeDeviceState
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.deye_dehumidifier.const import (
+    CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY,
+    DOMAIN,
+)
+from custom_components.deye_dehumidifier.data_coordinator import (
+    DeyeDataUpdateCoordinator,
+    DeyeDeviceData,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from tests.helpers import (
+    DEFAULT_STATE_HEX,
+    MOCK_CONFIG,
+    MOCK_DEVICE_INFO,
+    FakeDeyeDevice,
+)
+
+REFRESHED_STATE_HEX = "14118100113B00000000000000000040300000000000"
+
+
+def _make_coordinator(
+    hass: HomeAssistant, device: FakeDeyeDevice | None = None
+) -> tuple[DeyeDataUpdateCoordinator, FakeDeyeDevice]:
+    """Build a coordinator with initial data, without connecting MQTT."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="user-123",
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    if device is None:
+        device = FakeDeyeDevice(MOCK_DEVICE_INFO)
+    coordinator = DeyeDataUpdateCoordinator(hass, entry, device)
+    state = device.reported_state
+    coordinator.data = DeyeDeviceData(state, state.copy(), True)
+    coordinator.state_update_muted = None
+    return coordinator, device
+
+
+async def test_classic_poll_returns_real_state(hass: HomeAssistant) -> None:
+    """Classic polling waits for the MQTT reply instead of returning the cache."""
+    coordinator, device = _make_coordinator(hass)
+    new_state = DeyeDeviceState(REFRESHED_STATE_HEX)
+
+    async def _push_state() -> None:
+        coordinator.update_device_state(new_state)
+
+    device.request_refresh = AsyncMock(side_effect=_push_state)
+
+    result = await coordinator._async_update_data()
+
+    assert result.reported_state == new_state
+    assert result.available is True
+    assert coordinator._classic_query_failures == 0
+
+
+async def test_classic_poll_cleans_up_waiter_after_timeout(
+    hass: HomeAssistant,
+) -> None:
+    """A timed-out Classic poll does not leave a waiter behind."""
+    coordinator, device = _make_coordinator(hass)
+    device.request_refresh = AsyncMock(return_value=None)
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.CLASSIC_STATE_QUERY_TIMEOUT",
+        0.01,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result is coordinator.data
+    assert result.available is True
+    assert coordinator._classic_query_failures == 1
+    assert coordinator._classic_poll_waiter is None
+    assert coordinator._classic_reload_unsub is None
+
+
+async def test_single_timeout_does_not_reload(hass: HomeAssistant) -> None:
+    """The first Classic timeout keeps the last state and does not recover yet."""
+    coordinator, device = _make_coordinator(hass)
+    device.request_refresh = AsyncMock(return_value=None)
+    coordinator._schedule_classic_recovery = MagicMock()
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.CLASSIC_STATE_QUERY_TIMEOUT",
+        0.01,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result.available is True
+    coordinator._schedule_classic_recovery.assert_not_called()
+
+
+async def test_repeated_timeouts_mark_unavailable_and_schedule_reload(
+    hass: HomeAssistant,
+) -> None:
+    """A second consecutive Classic timeout marks entities unavailable."""
+    coordinator, device = _make_coordinator(hass)
+    device.request_refresh = AsyncMock(return_value=None)
+    coordinator._classic_query_failures = CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY - 1
+
+    with patch(
+        "custom_components.deye_dehumidifier.data_coordinator.CLASSIC_STATE_QUERY_TIMEOUT",
+        0.01,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result.available is False
+    assert coordinator._poll_forced_unavailable is True
+    assert coordinator._classic_query_failures == CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY
+    assert coordinator._classic_reload_unsub is not None
+    coordinator.unsubscribe()
+    assert coordinator._classic_reload_unsub is None
+
+
+async def test_success_clears_failures_and_restores_availability(
+    hass: HomeAssistant,
+) -> None:
+    """A real reply after failures restores availability and cancels recovery."""
+    coordinator, device = _make_coordinator(hass)
+    new_state = DeyeDeviceState(REFRESHED_STATE_HEX)
+    coordinator.data = DeyeDeviceData(new_state, new_state.copy(), False)
+    coordinator._classic_query_failures = CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY
+    coordinator._poll_forced_unavailable = True
+    coordinator._classic_reload_unsub = MagicMock()
+
+    async def _push_state() -> None:
+        coordinator.update_device_state(new_state)
+
+    device.request_refresh = AsyncMock(side_effect=_push_state)
+
+    result = await coordinator._async_update_data()
+
+    assert result.available is True
+    assert coordinator._classic_query_failures == 0
+    assert coordinator._poll_forced_unavailable is False
+    assert coordinator._classic_reload_unsub is None
+
+
+async def test_late_state_cancels_pending_reload(hass: HomeAssistant) -> None:
+    """A late MQTT payload restores availability and cancels a pending reload."""
+    coordinator, _device = _make_coordinator(hass)
+    coordinator._classic_query_failures = CLASSIC_QUERY_FAILURES_BEFORE_RECOVERY
+    coordinator._poll_forced_unavailable = True
+    coordinator.data = DeyeDeviceData(
+        coordinator.data.reported_state, coordinator.data.state, False
+    )
+    coordinator._schedule_classic_recovery()
+    assert coordinator._classic_reload_unsub is not None
+
+    new_state = DeyeDeviceState(REFRESHED_STATE_HEX)
+    coordinator.update_device_state(new_state)
+
+    assert coordinator._classic_query_failures == 0
+    assert coordinator._poll_forced_unavailable is False
+    assert coordinator._classic_reload_unsub is None
+    assert coordinator.data.available is True
+    assert coordinator.data.reported_state == new_state
+
+
+async def test_forced_unavailable_ignores_online_until_state(
+    hass: HomeAssistant,
+) -> None:
+    """An online topic must not clear a poll-forced unavailable state."""
+    coordinator, _device = _make_coordinator(hass)
+    coordinator._poll_forced_unavailable = True
+    coordinator.data = DeyeDeviceData(
+        coordinator.data.reported_state, coordinator.data.state, False
+    )
+
+    coordinator.update_device_availability(True)
+
+    assert coordinator.data.available is False
+    assert coordinator._poll_forced_unavailable is True
+
+
+async def test_fog_poll_does_not_wait_for_mqtt(hass: HomeAssistant) -> None:
+    """Fog HTTP poll success is enough; it must not wait for an MQTT payload."""
+    info = {**MOCK_DEVICE_INFO, "platform": DeyeIotPlatform.Fog}
+    device = FakeDeyeDevice(info)
+    device.request_refresh = AsyncMock(return_value=None)
+    coordinator, _ = _make_coordinator(hass, device)
+
+    result = await coordinator._async_update_data()
+
+    assert result is coordinator.data
+    assert coordinator._classic_query_failures == 0
+    device.request_refresh.assert_awaited_once()
+
+
+async def test_combo_poll_waits_for_mqtt_reply(hass: HomeAssistant) -> None:
+    """Combo uses Classic MQTT transport and must wait for status/hex."""
+    info = {
+        **MOCK_DEVICE_INFO,
+        "is_combo": True,
+        "protocol_version": COMBO_PROTOCOL_VERSION,
+    }
+    device = FakeDeyeDevice(info)
+    coordinator, _ = _make_coordinator(hass, device)
+    new_state = DeyeDeviceState(REFRESHED_STATE_HEX)
+
+    async def _push_state() -> None:
+        coordinator.update_device_state(new_state)
+
+    device.request_refresh = AsyncMock(side_effect=_push_state)
+
+    result = await coordinator._async_update_data()
+
+    assert result.reported_state == new_state
+    assert result.available is True
+
+
+async def test_fog_http_timeout_raises_update_failed(hass: HomeAssistant) -> None:
+    """A Fog HTTP timeout is a connection failure, not a Classic MQTT miss."""
+    info = {**MOCK_DEVICE_INFO, "platform": DeyeIotPlatform.Fog}
+    device = FakeDeyeDevice(info)
+    device.request_refresh = AsyncMock(side_effect=TimeoutError("http"))
+    coordinator, _ = _make_coordinator(hass, device)
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    assert coordinator._classic_query_failures == 0
+    assert coordinator._classic_reload_unsub is None
+
+
+async def test_muted_poll_returns_cache(hass: HomeAssistant) -> None:
+    """A mute window skips polling so optimistic local state is not overwritten."""
+    coordinator, device = _make_coordinator(hass)
+    coordinator.state_update_muted = MagicMock()
+    device.request_refresh = AsyncMock()
+
+    result = await coordinator._async_update_data()
+
+    assert result is coordinator.data
+    device.request_refresh.assert_not_called()
+
+
+async def test_setup_classic_device_receives_refresh_reply(
+    hass: HomeAssistant,
+) -> None:
+    """Full first refresh succeeds when FakeDeyeDevice echoes the current state."""
+    coordinator, device = _make_coordinator(hass)
+    device.reported_state = DeyeDeviceState(DEFAULT_STATE_HEX)
+    await coordinator._async_setup()
+
+    result = await coordinator._async_update_data()
+
+    assert result.reported_state == device.reported_state
+    assert result.available is True
+    assert coordinator._classic_query_failures == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #105.

## Problem

Classic/Combo coordinators published a state query and immediately returned the last cached `self.data`. If the long-lived MQTT client (or Paho network thread) stopped delivering messages, Home Assistant kept showing stale, still-available entities. Control from HA failed, while the official App and a fresh `deye-cli` process continued to work. Reloading the integration recovered immediately.

`MqttDisconnectMonitor` only inspects paho `is_connected()` and raises a repair. It cannot see a zombie connection that still looks connected but no longer receives `status/hex`.

## Change

Classic and Combo polls now wait up to 12 seconds for a real MQTT state payload on the existing long-lived subscription (no extra subscribe/unsubscribe). Fog still uses the HTTP `RealData` poll and does not wait.

- First timeout: keep the last known state and log a warning
- Second consecutive timeout: mark entities unavailable and reload the config entry after 5 seconds so the pooled MQTT client is destroyed and recreated
- A later real state payload clears the failure count, restores availability, and cancels a pending reload
- An `online` topic must not clear a poll-forced unavailable state

## Tests

Adds coordinator coverage for:

- Classic/Combo polls returning the received state
- Timeout cleanup of the in-flight waiter
- Single timeout not reloading
- Repeated timeouts marking unavailable and scheduling reload
- Success and late MQTT payloads cancelling recovery
- Fog HTTP success not waiting, and Fog HTTP `TimeoutError` becoming `UpdateFailed`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4851af22-721f-4301-b502-c71a1287b8ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4851af22-721f-4301-b502-c71a1287b8ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

