### PR TITLE
chore: bump integration to 3.0.2 and libdeye to 3.0.4

### DIFF
--- a/custom_components/deye_dehumidifier/manifest.json
+++ b/custom_components/deye_dehumidifier/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/stackia/ha-deye-dehumidifier",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/stackia/ha-deye-dehumidifier/issues",
-  "requirements": ["libdeye==3.0.3"],
-  "version": "3.0.1"
+  "requirements": ["libdeye==3.0.4"],
+  "version": "3.0.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-deye-dehumidifier"
-version = "3.0.1"
+version = "3.0.2"
 description = "Home Assistant integration for Deye Dehumidifier"
 readme = "README.md"
 license = "MIT"
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Home Automation",
 ]
 dependencies = [
-    "libdeye==3.0.3",
+    "libdeye==3.0.4",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "ha-deye-dehumidifier"
-version = "3.0.1"
+version = "3.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "libdeye" },
@@ -1165,7 +1165,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "libdeye", specifier = "==3.0.3" }]
+requires-dist = [{ name = "libdeye", specifier = "==3.0.4" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1435,16 +1435,16 @@ wheels = [
 
 [[package]]
 name = "libdeye"
-version = "3.0.3"
+version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "paho-mqtt" },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/8c/126f7f695055cbab0e54e8dbc673dcc25b8991ad72e5ae935c77fa1edab3/libdeye-3.0.3.tar.gz", hash = "sha256:627fa36e0decefbb9cfb86c03c1d9845e38f6518c1d29913ebeaf858a45de223", size = 842856, upload-time = "2026-09-03T08:40:48.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/46/8dd2aeadf2a97d5d2958ee72e84d1e7a2b814530a5bbebb1ca18e034fa7c/libdeye-3.0.4.tar.gz", hash = "sha256:22e5664b5cf5487a9739259b67693a98ef0eb7a42137e4d891697a4df26398f4", size = 845092, upload-time = "2026-09-04T02:46:11.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ed/8d85e5650c5a365c625d3d68e44e88e6e7b24c732d21b5c53da35fafbcb3/libdeye-3.0.3-py3-none-any.whl", hash = "sha256:7783a1249c6f0a4f9b9643c98896d227b0b0ccf6c73fb17a377931ac2487fad7", size = 30419, upload-time = "2026-09-03T08:40:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/47/94/c820c5bc4a24caa52cf2027cd06e0b0a8a5103ac7a8ed0273761377d4178/libdeye-3.0.4-py3-none-any.whl", hash = "sha256:bcdc836f4e1cccf62157431eed5483452e7fd409284157c0c2b680f7264c91d0", size = 31186, upload-time = "2026-09-04T02:46:10.827Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump the HACS integration to **3.0.2** and pin `libdeye==3.0.4`.

This is the HA-side delivery of [libdeye 3.0.4](https://pypi.org/project/libdeye/3.0.4/):

- MQTT-info refresh no longer blocks or kills paho's network thread when the cloud API is unreachable on disconnect (fixes https://github.com/stackia/libdeye/issues/67; also the root cause of https://github.com/stackia/ha-deye-dehumidifier/issues/105)
- Malformed MQTT payloads are logged and ignored instead of terminating the network thread

After merge, tag `v3.0.2` and publish the GitHub release so HACS can pick it up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b4b2d6e-e7ae-4cbc-97a3-cbf58f56fea1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b4b2d6e-e7ae-4cbc-97a3-cbf58f56fea1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

